### PR TITLE
How to not open ports on all interfaces

### DIFF
--- a/ironic/ironic_deployment_investigation.md
+++ b/ironic/ironic_deployment_investigation.md
@@ -23,3 +23,5 @@ There are 7 containers in an ironic pod:
 	+ Port 69: TFTP
             IP: 172.22.0.1-2 - ironicendpoint
 - ironic-log-watch: No change
+
+Note: In order to prevent ports to open on all interfaces, set LISTEN_ALL_INTERFACES = false


### PR DESCRIPTION
Update the doc to state that it is optional to open ironic ports on either all interfaces or only ironic-related interface.