### PR TITLE
Add investigation about meta provider

### DIFF
--- a/meta-provider/meta-provider/BYOH+metal3/Vagrantfile
+++ b/meta-provider/meta-provider/BYOH+metal3/Vagrantfile
@@ -1,0 +1,46 @@
+# -*- mode: ruby -*-
+
+hosts = {
+    "control-plane1" => { "memory" => 2048, "ip" => "192.168.10.10"},
+    # "worker1" => { "memory" => 2048, "ip" => "192.168.10.30"},
+    # "worker2" => { "memory" => 2048, "ip" => "192.168.10.31"},
+}
+
+Vagrant.configure("2") do |config|
+    # Choose which box you want below
+    # config.vm.box = "generic/centos8"
+    config.vm.box = "generic/ubuntu2004"
+
+    config.vm.synced_folder ".", "/vagrant", disabled: true
+
+    config.vm.provider :libvirt do |libvirt|
+      # QEMU system connection is required for private network configuration
+      libvirt.qemu_use_session = false
+    end
+
+    # Loop over all machine names
+    hosts.each_key do |host|
+        config.vm.define host, primary: host == hosts.keys.first do |node|
+            # Use custom box if set
+            if hosts[host]["box"]
+                node.vm.box = hosts[host]["box"]
+            end
+
+            node.vm.hostname = host
+            node.vm.network :private_network, ip: hosts[host]["ip"],
+              libvirt__forward_mode: "route"
+
+            node.vm.provider :libvirt do |lv|
+                lv.memory = hosts[host]["memory"]
+                lv.cpus = 2
+            end
+
+            node.vm.provider :virtualbox do |vbox|
+                vbox.customize ["modifyvm", :id, "--memory", hosts[host]["memory"]]
+                vbox.cpus = 2
+            end
+
+        end
+    end
+
+end

--- a/meta-provider/meta-provider/BYOH+metal3/byoh-components.yaml
+++ b/meta-provider/meta-provider/BYOH+metal3/byoh-components.yaml
@@ -1,0 +1,131 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    cni: byoh-cluster-crs-0
+    crs: "true"
+  name: byoh-cluster
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/16
+    serviceDomain: cluster.local
+    services:
+      cidrBlocks:
+      - 10.128.0.0/12
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: byoh-cluster-control-plane
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: ByoCluster
+    name: byoh-cluster
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  labels:
+    nodepool: pool0
+  name: byoh-cluster-control-plane
+spec:
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      apiServer:
+        certSANs:
+        - localhost
+        - 127.0.0.1
+        - 0.0.0.0
+        - host.docker.internal
+      controllerManager:
+        extraArgs:
+          enable-hostpath-provisioner: "true"
+    files:
+    - content: |
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          creationTimestamp: null
+          name: kube-vip
+          namespace: kube-system
+        spec:
+          containers:
+          - args:
+            - start
+            env:
+            - name: vip_arp
+              value: "true"
+            - name: vip_leaderelection
+              value: "true"
+            - name: vip_address
+              value: 192.168.10.20
+            - name: vip_interface
+              value: {{ .DefaultNetworkInterfaceName }}
+            - name: vip_leaseduration
+              value: "15"
+            - name: vip_renewdeadline
+              value: "10"
+            - name: vip_retryperiod
+              value: "2"
+            image: ghcr.io/kube-vip/kube-vip:v0.3.5
+            imagePullPolicy: IfNotPresent
+            name: kube-vip
+            resources: {}
+            securityContext:
+              capabilities:
+                add:
+                - NET_ADMIN
+                - SYS_TIME
+            volumeMounts:
+            - mountPath: /etc/kubernetes/admin.conf
+              name: kubeconfig
+          hostNetwork: true
+          volumes:
+          - hostPath:
+              path: /etc/kubernetes/admin.conf
+              type: FileOrCreate
+            name: kubeconfig
+        status: {}
+      owner: root:root
+      path: /etc/kubernetes/manifests/kube-vip.yaml
+    initConfiguration:
+      nodeRegistration:
+        criSocket: /var/run/containerd/containerd.sock
+        ignorePreflightErrors:
+        - Swap
+        - DirAvailable--etc-kubernetes-manifests
+        - FileAvailable--etc-kubernetes-kubelet.conf
+    joinConfiguration:
+      nodeRegistration:
+        criSocket: /var/run/containerd/containerd.sock
+        ignorePreflightErrors:
+        - Swap
+        - DirAvailable--etc-kubernetes-manifests
+        - FileAvailable--etc-kubernetes-kubelet.conf
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: ByoMachineTemplate
+      name: byoh-cluster-control-plane
+  replicas: 1
+  version: v1.23.5
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: ByoCluster
+metadata:
+  name: byoh-cluster
+spec:
+  bundleLookupBaseRegistry: projects.registry.vmware.com/cluster_api_provider_bringyourownhost
+  bundleLookupTag: v1.23.5
+  controlPlaneEndpoint:
+    host: 192.168.10.20
+    port: 6443
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: ByoMachineTemplate
+metadata:
+  name: byoh-cluster-control-plane
+spec:
+  template:
+    spec: {}

--- a/meta-provider/meta-provider/BYOH+metal3/metal3-cluster.yaml
+++ b/meta-provider/meta-provider/BYOH+metal3/metal3-cluster.yaml
@@ -1,0 +1,34 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: Metal3Cluster
+metadata:
+  name: byoh-cluster
+spec:
+  controlPlaneEndpoint:
+    host: 192.168.10.20
+    port: 6443
+  noCloudProvider: true
+---
+apiVersion: ipam.metal3.io/v1alpha1
+kind: IPPool
+metadata:
+  name: provisioning-pool
+spec:
+  clusterName: byoh-cluster
+  namePrefix: test1-prov
+  pools:
+  - end: 172.22.0.200
+    start: 172.22.0.100
+  prefix: 24
+---
+apiVersion: ipam.metal3.io/v1alpha1
+kind: IPPool
+metadata:
+  name: baremetalv4-pool
+spec:
+  clusterName: byoh-cluster
+  gateway: 192.168.111.1
+  namePrefix: test1-bmv4
+  pools:
+  - end: 192.168.111.200
+    start: 192.168.111.100
+  prefix: 24

--- a/meta-provider/meta-provider/BYOH+metal3/metal3-workers.yaml
+++ b/meta-provider/meta-provider/BYOH+metal3/metal3-workers.yaml
@@ -1,0 +1,182 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: byoh-cluster
+    nodepool: nodepool-0
+  name: test1
+spec:
+  clusterName: byoh-cluster
+  replicas: 1
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: byoh-cluster
+      nodepool: nodepool-0
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: byoh-cluster
+        nodepool: nodepool-0
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: test1-workers
+      clusterName: byoh-cluster
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: Metal3MachineTemplate
+        name: test1-workers
+      nodeDrainTimeout: 0s
+      version: v1.23.5
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: Metal3MachineTemplate
+metadata:
+  name: test1-workers
+spec:
+  template:
+    spec:
+      dataTemplate:
+        name: test1-workers-template
+      image:
+        checksum: http://172.22.0.1/images/CENTOS_9_NODE_IMAGE_K8S_v1.23.5-raw.img.md5sum
+        checksumType: md5
+        format: raw
+        url: http://172.22.0.1/images/CENTOS_9_NODE_IMAGE_K8S_v1.23.5-raw.img
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: Metal3DataTemplate
+metadata:
+  name: test1-workers-template
+spec:
+  clusterName: byoh-cluster
+  metaData:
+    ipAddressesFromIPPool:
+    - key: provisioningIP
+      name: provisioning-pool
+    objectNames:
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine
+    prefixesFromIPPool:
+    - key: provisioningCIDR
+      name: provisioning-pool
+  networkData:
+    links:
+      ethernets:
+      - id: enp1s0
+        macAddress:
+          fromHostInterface: enp1s0
+        type: phy
+      - id: enp2s0
+        macAddress:
+          fromHostInterface: enp2s0
+        type: phy
+    networks:
+      ipv4:
+      - id: baremetalv4
+        ipAddressFromIPPool: baremetalv4-pool
+        link: enp2s0
+        routes:
+        - gateway:
+            fromIPPool: baremetalv4-pool
+          network: 0.0.0.0
+          prefix: 0
+    services:
+      dns:
+      - 8.8.8.8
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: test1-workers
+spec:
+  template:
+    spec:
+      files:
+      - content: |
+          #!/bin/bash
+          set -e
+          url="$1"
+          dst="$2"
+          filename="$(basename $url)"
+          tmpfile="/tmp/$filename"
+          curl -sSL -w "%{http_code}" "$url" | sed "s:/usr/bin:/usr/local/bin:g" > /tmp/"$filename"
+          http_status=$(cat "$tmpfile" | tail -n 1)
+          if [ "$http_status" != "200" ]; then
+            echo "Error: unable to retrieve $filename file";
+            exit 1;
+          else
+            cat "$tmpfile"| sed '$d' > "$dst";
+          fi
+        owner: root:root
+        path: /usr/local/bin/retrieve.configuration.files.sh
+        permissions: "0755"
+      - content: |
+          BOOTPROTO=none
+          DEVICE=eth0
+          ONBOOT=yes
+          TYPE=Ethernet
+          USERCTL=no
+          BRIDGE=ironicendpoint
+        owner: root:root
+        path: /etc/sysconfig/network-scripts/ifcfg-eth0
+        permissions: "0644"
+      - content: |
+          TYPE=Bridge
+          DEVICE=ironicendpoint
+          ONBOOT=yes
+          USERCTL=no
+          BOOTPROTO="static"
+          IPADDR={{ ds.meta_data.provisioningIP }}
+          PREFIX={{ ds.meta_data.provisioningCIDR }}
+        owner: root:root
+        path: /etc/sysconfig/network-scripts/ifcfg-ironicendpoint
+        permissions: "0644"
+      - content: |
+          [kubernetes]
+          name=Kubernetes
+          baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+          enabled=1
+          gpgcheck=1
+          repo_gpgcheck=0
+          gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+        owner: root:root
+        path: /etc/yum.repos.d/kubernetes.repo
+        permissions: "0644"
+      - content: |
+          [registries.search]
+          registries = ['docker.io']
+
+          [registries.insecure]
+          registries = ['192.168.111.1:5000']
+        owner: root:root
+        path: /etc/containers/registries.conf
+        permissions: "0644"
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            cgroup-driver: systemd
+            container-runtime: remote
+            container-runtime-endpoint: unix:///var/run/crio/crio.sock
+            feature-gates: AllAlpha=false
+            node-labels: metal3.io/uuid={{ ds.meta_data.uuid }}
+            provider-id: metal3://{{ ds.meta_data.uuid }}
+            runtime-request-timeout: 5m
+          name: '{{ ds.meta_data.name }}'
+      preKubeadmCommands:
+      - systemctl restart NetworkManager.service
+      - nmcli connection load /etc/sysconfig/network-scripts/ifcfg-eth0
+      - nmcli connection up filename /etc/sysconfig/network-scripts/ifcfg-eth0
+      - systemctl enable --now crio kubelet
+      users:
+      - name: metal3
+        sshAuthorizedKeys:
+        - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC48zS2PJKInW6O8QxA1Ugvhad1qkl01XydfdTNR4deqAAiwn8KdHftQCwOTPmrK2QFEf6Pax86gSbcBmFRQwgS/1WkkAa00e+btTKD7BFDuMTXwDNiQLtFdpoWnWVj93Vb5cTIRDG3biaVup2koqODyzpshUvlT9POEQ+ri18LhC/Klk4JA4M7tW9e/gdptAKjyYPMQygrkeuwATrocEMxBrbypQzDkRfqgIXPqcENLBrtt7bDuv94/bUzHq5CLi9M+WJfItTdGNkezkonmDlf2DSMTTgx/ApRmnGsAqjIZnKYN44u8b1ax4oUAqd6lei0Ed3lAm1DQZAh4sApUEBpZdzSOZnoK51XvI36586kSwk5BnrqtpmiIWc77zebIedEc0N0PppD50gNKYKPNkYpwcIwzTU6Ds4ets8V0P96yyxMkEHxgqvFM5uNrfnYNPUTTxICsdd5NN+e1qs4XJ3RaF3bnEQOYSTtKF5gIgzXiBm8JCV0LVar4l0NVMGySAM=
+          ubuntu@lennart-test
+        sudo: ALL=(ALL) NOPASSWD:ALL

--- a/meta-provider/meta-provider/README.md
+++ b/meta-provider/meta-provider/README.md
@@ -1,0 +1,132 @@
+# Meta provider notes
+
+## BYOH provider
+
+The Bring-Your-Own-Host provider was chosen for this test for two reasons:
+
+1. Due to its design (you provision the host yourself), it is very easy to set up the hosts in various ways to accommodate the test (e.g. use a VM in the same network that the metal3-dev-env uses).
+2. It was mentioned on slack as one of the providers that works when combining multiple providers for a single cluster.
+
+**The test was successful**: It is possible to combine BYOH and metal3 to create a single cluster.
+More details below.
+
+## Test BYOH + Metal3
+
+On a high level this is how it is done:
+
+1. Create a cluster and control plane backed by the BYO provider (but no MachineDeployment).
+2. Create a metal3cluster and related resources with control plane endpoint pointing to the BYO control plane.
+
+This is all it takes to make it "work", but of course there are still some weird things.
+For example the Cluster only has one infrastructureRef and it is pointing to the BYO provider, as seen here:
+
+```yaml
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: byoh-cluster
+spec:
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: byoh-cluster-control-plane
+  # Note: Only a single infrastructureRef is allowed.
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: ByoCluster
+    name: byoh-cluster
+...
+```
+
+### Detailed steps
+
+See the manifests in `BYOH+metal3`.
+
+1. Set up metal3-dev-env on ubuntu and run `make`
+2. Add another VM to use as a BYOHost: `vagrant up`
+3. Initialize the BYO provider and register the BYO host
+   On the management host:
+   ```bash
+   clusterctl init --infrastructure byoh
+   cp ~/.kube/config ~/.kube/management-cluster.conf
+   export KIND_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' kind-control-plane)
+   sed -i 's/    server\:.*/    server\: https\:\/\/'"$KIND_IP"'\:6443/g' ~/.kube/management-cluster.conf
+   scp -i .vagrant/machines/control-plane1/libvirt/private_key /home/ubuntu/.kube/management-cluster.conf vagrant@192.168.10.10:management-cluster.conf
+   ```
+   On the BYOH:
+   ```bash
+   sudo apt-get install socat ebtables ethtool conntrack
+   wget https://github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/releases/download/v0.2.0/byoh-hostagent-linux-amd64
+   mv byoh-hostagent-linux-amd64 byoh-hostagent
+   chmod +x byoh-hostagent
+   sudo ./byoh-hostagent --kubeconfig management-cluster.conf
+   ```
+4. Apply BYO manifest to create a cluster with control plane from BYO
+   Note: You should do this in the same namespace where the BMHs are!
+   ```bash
+   kubectl -n metal3 apply -f BYOH+metal3/byoh-components.yaml
+   ```
+5. Apply the Metal3 manifests to add a MachineDeployment with metal3 as provider.
+   Note: You will need to replace the `sshAuthorizedKeys` with your own to get ssh access to the BMHs.
+   ```bash
+   kubectl -n metal3 apply -f BYOH+metal3/metal3-cluster.yaml
+   kubectl -n metal3 apply -f BYOH+metal3/metal3-workers.yaml
+   ```
+
+**Result:** The BYOHost is used to create the control plane and the BMHosts are joined to it as workers. 🎉
+
+## Nested provider
+
+This provider was chosen for the test because it runs the control plane as pods in the management cluster, which is desirable to avoid wasting resources on extra machines.
+However, there are some concerns about the suitability and usefulness:
+
+- [There is no scheduler](https://github.com/kubernetes-sigs/cluster-api-provider-nested/blob/main/controlplane/nested/api/v1alpha4/nestedcontrolplane_types.go#L36-L47) in the NestedControlPlaneSpec.
+  - Instead of scheduler, vcluster uses a "syncer" to [synchronize some resources](https://www.vcluster.com/docs/architecture/synced-resources) between the nested cluster and the "super cluster".
+- The Nested provider does not use the KubeadmControlPlane, instead it has a NestedControlPlane.
+  - The necessary config for joining is not available.
+    There should be a configmap `cluster-info` in the `kube-public` namespace along with RBAC to allow `system:anonymous` access.
+- This provider seems to be in early stages of development
+  - Only CAPI v1alpha4 is supported.
+  - Minimal docs and only one release.
+  - Scaling of control plane components is not implemented (but possible via StatefulSets)
+
+**The test was not successful**: Since the nested provider doesn't have its own nodes and doesn't use the KubeadmControlPlane provider, it doesn't provide the necessary resources to join nodes to the cluster.
+
+### Test Nested + Metal3
+
+See the manifests in `nested+metal3`.
+
+1. Setup metal3-dev-env for CAPI v1alpha4 on Ubuntu and run `make`.
+2. Initialize the nested provider.
+3. Follow the docs for [how to create a nested cluster](https://github.com/kubernetes-sigs/cluster-api-provider-nested/tree/main/docs#set-clustername-in-our-example-we-set-clustername-to-cluster-sample).
+4. Set up metallb in the KinD cluster using [this guide](https://kind.sigs.k8s.io/docs/user/loadbalancer/).
+5. Change the API server Service of the nested cluster to be of LoadBalancer type
+6. Edit the KubeadmConfigTemplate so that it adds the LoadBalancer IP to `/etc/hosts`, e.g. add this to `preKubeadmCommands`:
+   ```
+   echo "172.18.255.200 cluster-sample-apiserver" >> /etc/hosts
+   ```
+   You may also want to set a password so you can use `virsh console` to check the status of the VM easily.
+7. Apply the metal3 manifests
+
+**Result:** The BMH is provisioned, but the Machine stays in Provisioning since it is unable to join the cluster.
+Inspecting the kubelet logs and cloud-init reveals that the reason is that it cannot get the `cluster-info` configmap in order to validate the API server.
+The necessary RBAC is not in place, and the configmap is also missing.
+However, the Machine was able to reach the control plane, so that is at least something.
+
+It would be possible to add this configmap and RBAC of course, but there would likely be issues also after fixing this.
+For example, there is no scheduler in the nested cluster so there is no way to schedule pods on the nodes even if they managed to join.
+
+## Links
+
+- [Nested provider](https://github.com/kubernetes-sigs/cluster-api-provider-nested)
+- [vcluster provider](https://github.com/loft-sh/cluster-api-provider-vcluster) - Very similar to the nested provider. Both use vcluster underneath.
+- [vcluster](https://www.vcluster.com/)
+- [BYOH provider](https://github.com/vmware-tanzu/cluster-api-provider-bringyourownhost)
+- [microvm provider](https://github.com/weaveworks-liquidmetal/cluster-api-provider-microvm) - suggested as one of the providers that works for multi provider clusters.
+- [Kamaji](https://github.com/clastix/kamaji) - a tool to build and operate a managed kubernetes service with control planes running in the managager cluster. Aims to become a CAPI provider.
+- [Slack thread discussing multiple providers for a single cluster](https://kubernetes.slack.com/archives/C8TSNPY4T/p1654074545843379)
+
+## TODO
+
+- Investigate BYO running in the management cluster as a container
+- Investigate kamaji

--- a/meta-provider/meta-provider/nested+metal3/metal3_config.sh
+++ b/meta-provider/meta-provider/nested+metal3/metal3_config.sh
@@ -1,0 +1,5 @@
+export CAPM3_VERSION=v1alpha5
+export KUBERNETES_VERSION="v1.21.2"
+export IMAGE_OS="ubuntu"
+export IMAGE_NAME="UBUNTU_20.04_NODE_IMAGE_K8S_v1.21.2.qcow2"
+export IMAGE_LOCATION="https://artifactory.nordix.org/artifactory/metal3/images/k8s_v1.21.2"

--- a/meta-provider/meta-provider/nested+metal3/nested-components.yaml
+++ b/meta-provider/meta-provider/nested+metal3/nested-components.yaml
@@ -1,0 +1,64 @@
+apiVersion: cluster.x-k8s.io/v1alpha4
+kind: Cluster
+metadata:
+  name: cluster-sample
+spec:
+  controlPlaneEndpoint:
+    host: cluster-sample-apiserver
+    port: 6443
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+    kind: NestedControlPlane
+    name: cluster-sample-control-plane
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    kind: NestedCluster
+    name: cluster-sample
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+kind: NestedCluster
+metadata:
+  name: cluster-sample
+spec:
+  controlPlaneEndpoint:
+    host: localhost
+    port: 6443
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+kind: NestedControlPlane
+metadata:
+  name: cluster-sample-control-plane
+spec:
+  apiserver:
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+    kind: NestedAPIServer
+    name: cluster-sample-nestedapiserver
+  controllerManager:
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+    kind: NestedControllerManager
+    name: cluster-sample-nestedcontrollermanager
+  etcd:
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+    kind: NestedEtcd
+    name: cluster-sample-nestedetcd
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+kind: NestedEtcd
+metadata:
+  name: cluster-sample-nestedetcd
+spec:
+  replicas: 1
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+kind: NestedAPIServer
+metadata:
+  name: cluster-sample-nestedapiserver
+spec:
+  replicas: 1
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+kind: NestedControllerManager
+metadata:
+  name: cluster-sample-nestedcontrollermanager
+spec:
+  replicas: 1

--- a/meta-provider/meta-provider/nested+metal3/v1alpha5_cluster_ubuntu.yaml
+++ b/meta-provider/meta-provider/nested+metal3/v1alpha5_cluster_ubuntu.yaml
@@ -1,0 +1,37 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
+kind: Metal3Cluster
+metadata:
+  name: cluster-sample
+  namespace: metal3
+spec:
+  controlPlaneEndpoint:
+    host: cluster-sample-apiserver
+    port: 6443
+  noCloudProvider: true
+---
+apiVersion: ipam.metal3.io/v1alpha1
+kind: IPPool
+metadata:
+  name: provisioning-pool
+  namespace: metal3
+spec:
+  clusterName: cluster-sample
+  namePrefix: test1-prov
+  pools:
+    - end: 172.22.0.200
+      start: 172.22.0.100
+  prefix: 24
+---
+apiVersion: ipam.metal3.io/v1alpha1
+kind: IPPool
+metadata:
+  name: baremetalv4-pool
+  namespace: metal3
+spec:
+  clusterName: cluster-sample
+  gateway: 192.168.111.1
+  namePrefix: test1-bmv4
+  pools:
+    - end: 192.168.111.200
+      start: 192.168.111.100
+  prefix: 24

--- a/meta-provider/meta-provider/nested+metal3/v1alpha5_workers_ubuntu.yaml
+++ b/meta-provider/meta-provider/nested+metal3/v1alpha5_workers_ubuntu.yaml
@@ -1,0 +1,149 @@
+apiVersion: cluster.x-k8s.io/v1alpha4
+kind: MachineDeployment
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: cluster-sample
+    nodepool: nodepool-0
+  name: test1
+  namespace: metal3
+spec:
+  clusterName: cluster-sample
+  replicas: 1
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: cluster-sample
+      nodepool: nodepool-0
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: cluster-sample
+        nodepool: nodepool-0
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha4
+          kind: KubeadmConfigTemplate
+          name: test1-workers
+      clusterName: cluster-sample
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
+        kind: Metal3MachineTemplate
+        name: test1-workers
+      nodeDrainTimeout: 0s
+      version: v1.21.2
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
+kind: Metal3MachineTemplate
+metadata:
+  name: test1-workers
+  namespace: metal3
+spec:
+  template:
+    spec:
+      dataTemplate:
+        name: test1-workers-template
+      image:
+        checksum: http://172.22.0.1/images/UBUNTU_20.04_NODE_IMAGE_K8S_v1.21.2-raw.img.md5sum
+        checksumType: md5
+        format: raw
+        url: http://172.22.0.1/images/UBUNTU_20.04_NODE_IMAGE_K8S_v1.21.2-raw.img
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
+kind: Metal3DataTemplate
+metadata:
+  name: test1-workers-template
+  namespace: metal3
+spec:
+  clusterName: cluster-sample
+  metaData:
+    ipAddressesFromIPPool:
+      - key: provisioningIP
+        name: provisioning-pool
+    objectNames:
+      - key: name
+        object: machine
+      - key: local-hostname
+        object: machine
+      - key: local_hostname
+        object: machine
+    prefixesFromIPPool:
+      - key: provisioningCIDR
+        name: provisioning-pool
+  networkData:
+    links:
+      ethernets:
+        - id: enp1s0
+          macAddress:
+            fromHostInterface: enp1s0
+          type: phy
+        - id: enp2s0
+          macAddress:
+            fromHostInterface: enp2s0
+          type: phy
+    networks:
+      ipv4:
+        - id: baremetalv4
+          ipAddressFromIPPool: baremetalv4-pool
+          link: enp2s0
+          routes:
+            - gateway:
+                fromIPPool: baremetalv4-pool
+              network: 0.0.0.0
+              prefix: 0
+    services:
+      dns:
+        - 8.8.8.8
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha4
+kind: KubeadmConfigTemplate
+metadata:
+  name: test1-workers
+  namespace: metal3
+spec:
+  template:
+    spec:
+      files:
+        - content: |
+            network:
+              version: 2
+              renderer: networkd
+              bridges:
+                ironicendpoint:
+                  interfaces: [enp1s0]
+                  addresses:
+                  - {{ ds.meta_data.provisioningIP }}/{{ ds.meta_data.provisioningCIDR }}
+          owner: root:root
+          path: /etc/netplan/52-ironicendpoint.yaml
+          permissions: "0644"
+        - content: |
+            [registries.search]
+            registries = ['docker.io']
+
+            [registries.insecure]
+            registries = ['192.168.111.1:5000']
+          path: /etc/containers/registries.conf
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            cgroup-driver: systemd
+            container-runtime: remote
+            container-runtime-endpoint: unix:///var/run/crio/crio.sock
+            feature-gates: AllAlpha=false
+            node-labels: metal3.io/uuid={{ ds.meta_data.uuid }}
+            provider-id: metal3://{{ ds.meta_data.uuid }}
+            runtime-request-timeout: 5m
+          name: "{{ ds.meta_data.name }}"
+      preKubeadmCommands:
+        - netplan apply
+        - systemctl enable --now crio kubelet
+        - echo "172.18.255.200 cluster-sample-apiserver" >> /etc/hosts
+      users:
+        - name: metal3
+          sshAuthorizedKeys:
+            - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC48zS2PJKInW6O8QxA1Ugvhad1qkl01XydfdTNR4deqAAiwn8KdHftQCwOTPmrK2QFEf6Pax86gSbcBmFRQwgS/1WkkAa00e+btTKD7BFDuMTXwDNiQLtFdpoWnWVj93Vb5cTIRDG3biaVup2koqODyzpshUvlT9POEQ+ri18LhC/Klk4JA4M7tW9e/gdptAKjyYPMQygrkeuwATrocEMxBrbypQzDkRfqgIXPqcENLBrtt7bDuv94/bUzHq5CLi9M+WJfItTdGNkezkonmDlf2DSMTTgx/ApRmnGsAqjIZnKYN44u8b1ax4oUAqd6lei0Ed3lAm1DQZAh4sApUEBpZdzSOZnoK51XvI36586kSwk5BnrqtpmiIWc77zebIedEc0N0PppD50gNKYKPNkYpwcIwzTU6Ds4ets8V0P96yyxMkEHxgqvFM5uNrfnYNPUTTxICsdd5NN+e1qs4XJ3RaF3bnEQOYSTtKF5gIgzXiBm8JCV0LVar4l0NVMGySAM=
+              ubuntu@lennart-test
+          sudo: ALL=(ALL) NOPASSWD:ALL
+          lockPassword: false
+          # generate with mkpasswd --method=SHA-512 --rounds=4096
+          # nerdvendor
+          passwd: $6$rounds=4096$EhcyaSgedVn6D9Qm$WTqrBEESsX6Qe0huYzEy0i13xEfLecPGGB184HvkiFm4SNxLq3WeVE0AA4.hWQz8CXkxqb7J05I6DErQ6qvvi1


### PR DESCRIPTION
The goal is to combine multiple CAPI infrastructure providers to create
a single cluster. Ideally, the control plane should run as pods in the
management cluster while the worker nodes consist of Metal3Machines.