### PR TITLE
markdown: pin mdl to 0.12.0 and fix complaints

### DIFF
--- a/PlatformAwareEnergy/README.md
+++ b/PlatformAwareEnergy/README.md
@@ -73,13 +73,13 @@ In order to be certain the raw metrics are available look at a specific endpoint
 
 - Deploy [Power Driven Scheduling and Scaling with CPU telemetry in Kubernetes](https://github.com/intel/platform-aware-scheduling/blob/master/telemetry-aware-scheduling/docs/power/README.md). Once you follow all the steps described above you will have the following:
 
-  - Deployed collectd and prometheus adapter. This exposes node's energy metrics to kubernetes and prometheus. Check the following picture for an example.
+   - Deployed collectd and prometheus adapter. This exposes node's energy metrics to kubernetes and prometheus. Check the following picture for an example.
 
   ![Prometheus node energy](images/prometheus_node_energy.png)
 
-  - Deployed Kube state metrics and makes it available to prometheus.
+   - Deployed Kube state metrics and makes it available to prometheus.
 
-  - Deployed TAS Telemetry Policy for power. You can check the policy as follows:
+   - Deployed TAS Telemetry Policy for power. You can check the policy as follows:
 
   ```bash
 
@@ -106,9 +106,9 @@ In order to be certain the raw metrics are available look at a specific endpoint
 
   ```
 
-  - Deployed horizontal autoscaler for power. The Horizontal Pod Autoscaler is an in-built part of Kubernetes which allows scaling decisions to be made based on arbitrary metrics. In this case we're going to scale our workload based on the average power usage on nodes with current instances of our workload.
+   - Deployed horizontal autoscaler for power. The Horizontal Pod Autoscaler is an in-built part of Kubernetes which allows scaling decisions to be made based on arbitrary metrics. In this case we're going to scale our workload based on the average power usage on nodes with current instances of our workload.
 
-  - Deployed power sensitive application. TAS schedules it to the node with the lowest power usage, and will avoid scheduling to any node with more than 80 percent of its TDP currently in use.
+   - Deployed power sensitive application. TAS schedules it to the node with the lowest power usage, and will avoid scheduling to any node with more than 80 percent of its TDP currently in use.
 
 ### Disadvantages
 

--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ The purpose of this repo is to centralize technical studies related to cluster-a
 
 ## Checks
 
-Markdownlint via `hacks/markdownlint.sh` will check the validity of markdown
+Markdownlint via `./hack/markdownlint.sh` will check the validity of markdown
 markup.

--- a/ca-rotation-study/README.md
+++ b/ca-rotation-study/README.md
@@ -210,11 +210,11 @@ For all the yaml files used in the tests, there are examples in this repository.
   ```
 
 - Results:
-  - Reprovisioning worker nodes is successful, `pki/ca.crt` contains both
+   - Reprovisioning worker nodes is successful, `pki/ca.crt` contains both
     certificates
-  - Reprovisioning control plane node is successful, `pki/ca.crt` contains both
+   - Reprovisioning control plane node is successful, `pki/ca.crt` contains both
     certificates
-  - Cluster works during and after the upgrade
+   - Cluster works during and after the upgrade
 
 ### Test 4: rotate cluster-ca key (after test 3)
 
@@ -235,10 +235,10 @@ For all the yaml files used in the tests, there are examples in this repository.
 
 - Start with a fresh cluster
 - On one worker node:
-  - Create a new CA certificate with openssl
-  - Update ca.crt to include new CA certificate and old CA certificate (in that
+   - Create a new CA certificate with openssl
+   - Update ca.crt to include new CA certificate and old CA certificate (in that
     order)
-  - Restart node
+   - Restart node
 - Result: connection to control plane is possible --> trusting two certificates
   works
 
@@ -250,8 +250,8 @@ For all the yaml files used in the tests, there are examples in this repository.
   configmap from the target cluster
 - Update CAs so each contains old CA certificate, new CA certificate and old
   key
-  - For cluster-ca update secret and configmap as in test 3
-  - For etcd and front-proxy, just secrets need to be updated, similar to test
+   - For cluster-ca update secret and configmap as in test 3
+   - For etcd and front-proxy, just secrets need to be updated, similar to test
     3 (see `update-etcd.yaml` and `update-proxy.yaml`)
 - Upgrade control plane nodes as in test 3
 - Result: Works, control plane is successfully upgraded
@@ -268,6 +268,6 @@ For all the yaml files used in the tests, there are examples in this repository.
   new key
 - Upgrade control plane nodes as before
 - Results:
-  - Works, control plane is successfully updated
-  - No split brain during upgrade
-  - Updated nodes do already have certificates signed by new CA
+   - Works, control plane is successfully updated
+   - No split brain during upgrade
+   - Updated nodes do already have certificates signed by new CA

--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -8,7 +8,7 @@ CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 if [ "${IS_CONTAINER}" != "false" ]; then
   TOP_DIR="${1:-.}"
   find "${TOP_DIR}" \
-       \( -path ./vendor -o -path ./.github \) \
+      \( -path ./vendor -o -path ./.github \) \
       -prune -o -name '*.md' -exec \
       mdl --style all --warnings \
       --rules "MD001,MD002,MD003,MD004,MD005,MD006,MD007,MD009,MD010,MD011,MD012,MD014,MD018,MD019,MD020,MD021,MD022,MD023,MD024,MD025,MD026,MD027,MD028,MD030,MD031,MD032,MD033,MD034,MD035,MD036,MD037,MD038,MD039,MD040,MD041" \
@@ -19,7 +19,7 @@ else
     --volume "${PWD}:/workdir:ro,z" \
     --entrypoint sh \
     --workdir /workdir \
-    registry.hub.docker.com/pipelinecomponents/markdownlint:latest \
+    registry.hub.docker.com/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2 \
     /workdir/hack/markdownlint.sh "${@}"
 fi;
 

--- a/ironic/ironic_deployment_investigation.md
+++ b/ironic/ironic_deployment_investigation.md
@@ -5,32 +5,32 @@ In Metal3, ironic is deployed in a container image, the repo of which can be fou
 There are 7 containers in an ironic pod:
 
 - `ironic`: This container has one ironic process. This process runs in the combined mode of ironic, as opposed to the separated mode where api and conductor parts run in two different processes.
-  - Port `6388`: Listens to api requests. These requests are handled by api part of ironic. In fact, the traffic coming to this port is mostly from the reverse proxy `ironic-httpd`.
-  - IP: `127.0.0.1` - Interface: Loop back
+   - Port `6388`: Listens to api requests. These requests are handled by api part of ironic. In fact, the traffic coming to this port is mostly from the reverse proxy `ironic-httpd`.
+   - IP: `127.0.0.1` - Interface: Loop back
 - `ironic-inspector`: No change
-  - Port `5049`: Listens to inspector requests. The traffic coming to this port is mostly from the reverse proxy `ironic-httpd`.
-  - IP: `127.0.0.1` - Interface: Loop back
+   - Port `5049`: Listens to inspector requests. The traffic coming to this port is mostly from the reverse proxy `ironic-httpd`.
+   - IP: `127.0.0.1` - Interface: Loop back
 - `ironic-httpd`:
-  - Port `6385`: Any traffic coming to this port is forwarded to port `6388` of ironic container.
-  - Port `5050`: Any traffic coming to this port is forwarded to port `5049` of ironic-inspector container.
-  - Port `6180`: Allows downloading IPA image
-  - IP (3 ports above): `0.0.0.0/0` - All interfaces
+   - Port `6385`: Any traffic coming to this port is forwarded to port `6388` of ironic container.
+   - Port `5050`: Any traffic coming to this port is forwarded to port `5049` of ironic-inspector container.
+   - Port `6180`: Allows downloading IPA image
+   - IP (3 ports above): `0.0.0.0/0` - All interfaces
 - `mariadb`: The use of mariadb is optional.
-  - Port `3306`: Database port. Ironic connects to this port to read and write node data.
-  - IP: `0.0.0.0/0` - all interfaces
+   - Port `3306`: Database port. Ironic connects to this port to read and write node data.
+   - IP: `0.0.0.0/0` - all interfaces
 - `sqlite`: When SQLite is used instead of mariadb there is no DBMS server/container the database exists on the file system of ironic and ironic-inspector and the database is accessed via the filesystem.
 - `ironic-keepalived`: No change
 - `ironic-dnsmasq`: No change
-  - Port `67`: bootstrap server. For PXE boot
-  - IP: `0.0.0.0/0`
-    - In case of local IPA deployment e.g. using kind with ubuntu
+   - Port `67`: bootstrap server. For PXE boot
+   - IP: `0.0.0.0/0`
+      - In case of local IPA deployment e.g. using kind with ubuntu
       it is only open on the ironicendpoint interface.
-    - In case of deploying ironic as a cluster deployment as part of the BMO deployment the `ironic-dnsmasq` container
+      - In case of deploying ironic as a cluster deployment as part of the BMO deployment the `ironic-dnsmasq` container
       opens port `67` on all interfaces and it will be visible from the host network too.
       Although it is open on all interfaces it only accepts DHCP/BOOTP communication on the `ironicendpoint` interface
       It also only broadcasts DHCP/BOOTP packages on the `ironicendpoint` interface.
-  - Port `69`: TFTP
-  - IP: `172.22.0.1-2` - ironicendpoint
+   - Port `69`: TFTP
+   - IP: `172.22.0.1-2` - ironicendpoint
 - `ironic-log-watch`: No change
 
 Note: In order to prevent ports `6385` of the httpd and `5050` of the ironic-inspector to be opened on all interfaces, set `LISTEN_ALL_INTERFACES = false`

--- a/lb-haproxy-study/README.md
+++ b/lb-haproxy-study/README.md
@@ -11,9 +11,9 @@
 #### General
 
 * Check how iptables setting works
-  * 'Done, outcome here'
+   * 'Done, outcome here'
 * Check how nc or etc. tunneling configuration works
-  * 'Done, outcome here'
+   * 'Done, outcome here'
 
 #### HAProxy running outside a cluster as an external service
 
@@ -22,13 +22,13 @@ HAProxy config has to contain port mapping from port used in `kubeam --control-p
 No need for iptables or socat tunneling for port forwarding from LB port to API server port.
 
 * Option1 Periodical polling of configmap with token
-  * HAProxy config update logic service runs as an external service reading configmap content using access token. Token is generated in cloud init phase after kubeadm init and serviceaccount creation is made. This account gives rights to read configmaps. Token can be exposed to config update process as environment variable.
-  * HAProxy update logic periodically reads the status of configmap and if configmap is changed, it will update master node IP addresses `/etc/haproxy/haproxy.cfg` and then restarts HAProxy with systemctl command.
+   * HAProxy config update logic service runs as an external service reading configmap content using access token. Token is generated in cloud init phase after kubeadm init and serviceaccount creation is made. This account gives rights to read configmaps. Token can be exposed to config update process as environment variable.
+   * HAProxy update logic periodically reads the status of configmap and if configmap is changed, it will update master node IP addresses `/etc/haproxy/haproxy.cfg` and then restarts HAProxy with systemctl command.
 
 * Option2 Configmap mounted as host volume
-  * Configmap is mounted as host volume into haproxy.cfg file so that haproxy can use that as is when soft link created between mounted haproxy.cfg and config location haproxy uses in restart
-  * systemctl path unit used to detect changes in mounter haproxy.cfg and trigger service restarting haproxy in case changes occur.
-  * Haproxy has internal logic to do restart gracefully.
+   * Configmap is mounted as host volume into haproxy.cfg file so that haproxy can use that as is when soft link created between mounted haproxy.cfg and config location haproxy uses in restart
+   * systemctl path unit used to detect changes in mounter haproxy.cfg and trigger service restarting haproxy in case changes occur.
+   * Haproxy has internal logic to do restart gracefully.
 
 #### HAProxy as a daemonset
 
@@ -36,20 +36,20 @@ No need for iptables or socat tunneling for port forwarding from LB port to API 
 * After port forwarding is activated `kubeadm init` can be run with option `--control-plane-endpoint LB port`
 
 * Option1, HAProxy and sidecar:
-  * After cluster is up, HAProxy with config update sidecar pod is created. Sidecar container uses serviceaccount token to periodically poll configmap status from API server
-  * Sidecar and HAProxy containers share the same volume so that sidecar can update HAProxy config directly to `/etc/haproxy/haproxy.cfg`
-  * Sidecar periodically reads the status of configmap and if configmap is changed, it will update master node IP addresses `/etc/haproxy/haproxy.cfg` and then exec to HAProxy container and restarts HAProxy process with systemctl command
-  * Sidecar and HAProxy can use 'shareProcessNamespace:true' and thus Sidecar can reboot HAProxy by killing its process
-  * Alternatively a daemonset pod could be deleted to force cfg-file reading but this would require kubectl and is not preferred due to security reasons
-  * Test environment can be found in `LB-HAProxy-ds-sc` directory
-  * Port mapping from nodePort to API server can be do with socat
+   * After cluster is up, HAProxy with config update sidecar pod is created. Sidecar container uses serviceaccount token to periodically poll configmap status from API server
+   * Sidecar and HAProxy containers share the same volume so that sidecar can update HAProxy config directly to `/etc/haproxy/haproxy.cfg`
+   * Sidecar periodically reads the status of configmap and if configmap is changed, it will update master node IP addresses `/etc/haproxy/haproxy.cfg` and then exec to HAProxy container and restarts HAProxy process with systemctl command
+   * Sidecar and HAProxy can use 'shareProcessNamespace:true' and thus Sidecar can reboot HAProxy by killing its process
+   * Alternatively a daemonset pod could be deleted to force cfg-file reading but this would require kubectl and is not preferred due to security reasons
+   * Test environment can be found in `LB-HAProxy-ds-sc` directory
+   * Port mapping from nodePort to API server can be do with socat
     before mapping deployed inside crluster: `sudo socat tcp-l:31117,fork,reuseaddr tcp:127.0.0.1:6443`
 * Option2, HAProxy reads configmap which is mounted as a volume
-  * A delay (~60 sec) is identified when configmap is modified until the HAProxy sees the change, not seen as an issue at least for now
+   * A delay (~60 sec) is identified when configmap is modified until the HAProxy sees the change, not seen as an issue at least for now
 
 * Option3, run an initial Load balancer (here HAProxy) on ephemeral cluster - a proposal from CAPI developer meeting
-  * LB with port forwarding (e.g port `1234` -> `master-0-IP:6443`) is created in ephemeral cluster cloud-init phase (or deploy to ephemeral cluster?). Ephemeral cluster has keepalived owning VIP. Target cluster master-0 kubeadm init created with kubeconfig having access IP VIP:1234, then daemonset LB with port `1234` -> `mastersIP[]:6443` mapping created. Finally keepalived can be deactivated from ephemeral cluster
-  * keepalived takes care of the switch from ephemeral to target node/cluster
+   * LB with port forwarding (e.g port `1234` -> `master-0-IP:6443`) is created in ephemeral cluster cloud-init phase (or deploy to ephemeral cluster?). Ephemeral cluster has keepalived owning VIP. Target cluster master-0 kubeadm init created with kubeconfig having access IP VIP:1234, then daemonset LB with port `1234` -> `mastersIP[]:6443` mapping created. Finally keepalived can be deactivated from ephemeral cluster
+   * keepalived takes care of the switch from ephemeral to target node/cluster
 
 #### Visualization
 
@@ -63,5 +63,5 @@ No need for iptables or socat tunneling for port forwarding from LB port to API 
 
 * Metal3-dev-env, primary test env, iterations take time
 * Cloud-init testing in Vagrant nodes, no applicable environment available now
-  * Trial done with [Vagrant-cloud-init](https://github.com/craighurley/vagrant-cloud-init.git). Additional effort needed to get it working. Testing modified cloud-init is problematic
+   * Trial done with [Vagrant-cloud-init](https://github.com/craighurley/vagrant-cloud-init.git). Additional effort needed to get it working. Testing modified cloud-init is problematic
 * Option1: LB-HAProxy-ds-sc directory

--- a/meta-provider/README.md
+++ b/meta-provider/README.md
@@ -107,14 +107,14 @@ This provider was chosen for the test because it runs the control plane as pods 
 However, there are some concerns about the suitability and usefulness:
 
 - [There is no scheduler](https://github.com/kubernetes-sigs/cluster-api-provider-nested/blob/main/controlplane/nested/api/v1alpha4/nestedcontrolplane_types.go#L36-L47) in the NestedControlPlaneSpec.
-  - Instead of scheduler, vcluster uses a "syncer" to [synchronize some resources](https://www.vcluster.com/docs/architecture/synced-resources) between the nested cluster and the "super cluster".
+   - Instead of scheduler, vcluster uses a "syncer" to [synchronize some resources](https://www.vcluster.com/docs/architecture/synced-resources) between the nested cluster and the "super cluster".
 - The Nested provider does not use the KubeadmControlPlane, instead it has a NestedControlPlane.
-  - The necessary config for joining is not available.
+   - The necessary config for joining is not available.
     There should be a configmap `cluster-info` in the `kube-public` namespace along with RBAC to allow `system:anonymous` access.
 - This provider seems to be in early stages of development
-  - Only CAPI v1alpha4 is supported.
-  - Minimal docs and only one release.
-  - Scaling of control plane components is not implemented (but possible via StatefulSets)
+   - Only CAPI v1alpha4 is supported.
+   - Minimal docs and only one release.
+   - Scaling of control plane components is not implemented (but possible via StatefulSets)
 
 **The test was not successful**: Since the nested provider doesn't have its own nodes and doesn't use the KubeadmControlPlane provider, it doesn't provide the necessary resources to join nodes to the cluster.
 
@@ -241,9 +241,9 @@ See the manifests in `vcluster`.
 - Disabling the syncer causes the kubeconfig to not be created in the management cluster.
   But it can be extracted from the container (k3s) or from the vcluster-certs secret (k8s).
 - k8s:
-  - Manually remove the syncer deployment (named `vcluster`). It is not possible to remove with helm values.
-  - Edit the scheduler command to remove `--port=0`.
-  - The cluster-info configmap is missing
+   - Manually remove the syncer deployment (named `vcluster`). It is not possible to remove with helm values.
+   - Edit the scheduler command to remove `--port=0`.
+   - The cluster-info configmap is missing
 
 **Conclusion:** The necessary changes to support our use case would be to
 

--- a/metal3/AIR-146_non-default-ip-for-master.md
+++ b/metal3/AIR-146_non-default-ip-for-master.md
@@ -93,14 +93,14 @@ On the join side, it is “not possible” to set the etcd IP directly.
 Here we just pinpoint the answers for the questions asked in [Motivation](#motivation) section:
 
 * How do these components choose which interfaces to use?
-  * If no information is given, it takes the default interface
+   * If no information is given, it takes the default interface
 * How do we influence the choice during init phase?
-  * By providing relevant ips in kubeconfig file
+   * By providing relevant ips in kubeconfig file
 * How do we influence the choice during join phase?
-  * By providing relevant ips in kubeconfig file
+   * By providing relevant ips in kubeconfig file
 * How granular the configuration could be made?
-  * Only one IP works. I.e. both the api-server and etcd can have the same non-default IP.
-  * Though not likely, if it is desired that the api-server and the etcd use two distinct non-default IPs, then more investigation needs to be done.
+   * Only one IP works. I.e. both the api-server and etcd can have the same non-default IP.
+   * Though not likely, if it is desired that the api-server and the etcd use two distinct non-default IPs, then more investigation needs to be done.
 
 ## Sample Configurations
 

--- a/upgrade/README.md
+++ b/upgrade/README.md
@@ -12,23 +12,23 @@ Upgrade supported from current minor to next minor (e.g 1.16 to 1.17).
 Details in <https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/>
 
 * **upgrade with one extra node (or several extra nodes)**
-  * additional resource need, no capacity impact
-  * join node with new version (`kubeadm join`)
-    * workers with new k8s version can join the cluster but the workers will stay in `NotReady` state until
+   * additional resource need, no capacity impact
+   * join node with new version (`kubeadm join`)
+      * workers with new k8s version can join the cluster but the workers will stay in `NotReady` state until
       any control-plane node is upgraded to the new k8s version
-  * remove the old node from the cluster (`kubeadm reset -f`)
-  * Example cluster running on top of CentOS with loadbalancer, master1, 2, 3 and worker1, 2
-    * details described in README.md inside `usecases/upgrade-with-one-extra-node.zip`
+   * remove the old node from the cluster (`kubeadm reset -f`)
+   * Example cluster running on top of CentOS with loadbalancer, master1, 2, 3 and worker1, 2
+      * details described in README.md inside `usecases/upgrade-with-one-extra-node.zip`
 
 * **upgrade in place**
-  * capacity decrease during upgrade due to scale-in scale-out
-    * cordon the node to be upgraded and once finished, uncordon it
-  * trigger upgrade with `kubeadm upgrade`, nodes are upgraded sequentially
+   * capacity decrease during upgrade due to scale-in scale-out
+      * cordon the node to be upgraded and once finished, uncordon it
+   * trigger upgrade with `kubeadm upgrade`, nodes are upgraded sequentially
 
 * **upgrade with only one worker**
-  * scheduling is allowed on master(s) to avoid service downtime, capacity impact
-    * enable scheduling, remove taints `kubectl taint nodes --all node-role.kubernetes.io/master-`
-    * disable scheduling, set taint back `kubectl taint nodes control-plane-1 control-plane-1=DoNotSchedulePods:NoSchedule`
+   * scheduling is allowed on master(s) to avoid service downtime, capacity impact
+      * enable scheduling, remove taints `kubectl taint nodes --all node-role.kubernetes.io/master-`
+      * disable scheduling, set taint back `kubectl taint nodes control-plane-1 control-plane-1=DoNotSchedulePods:NoSchedule`
 
 ### Add/replace nodes to an existing cluster
 
@@ -36,15 +36,15 @@ Details in <https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-
 * Kubeadm upgrade is not used in this case
 * Add/replace should be supported between Kubernetes minor versions, e.g 1.16 to 1.17.
 * Example cluster running on top of CentOS with loadbalancer, master1, 2, 3, XX and worker1, 2
-  * details described in README.md inside `usecases/Add_replace_nodes_to_cluster.zip`
+   * details described in README.md inside `usecases/Add_replace_nodes_to_cluster.zip`
 
 ### Image update
 
 * <https://kubernetes.io/docs/tutorials/kubernetes-basics/update/update-interactive/>
 * <https://medium.com/platformer-blog/enable-rolling-updates-in-kubernetes-with-zero-downtime-31d7ec388c81>
-  * rolling update
-    * readiness probe secures the incoming requests being served at all times, "old" pod termination started after new ones are ready
-    * create a cluster, use e.g `usecases/Add_replace_nodes_to_cluster.zip`
+   * rolling update
+      * readiness probe secures the incoming requests being served at all times, "old" pod termination started after new ones are ready
+      * create a cluster, use e.g `usecases/Add_replace_nodes_to_cluster.zip`
 * image updating can be tested in the following way
 
 ```bash


### PR DESCRIPTION
mdl 0.12 moves unordered list indentation from 2 spaces to 3 spaces due Kramdown requirements.

Pin markdownlint image to 0.12 (with SHA), and fix all markdown comply with mdl 0.12.
