### PR TITLE
Fix multiple ironic scripts

### DIFF
--- a/Support/Multitenancy/Ironic_bmo-mult-instances/05-apply-manifests.sh
+++ b/Support/Multitenancy/Ironic_bmo-mult-instances/05-apply-manifests.sh
@@ -27,8 +27,12 @@ sudo mv ./clusterctl /usr/local/bin/clusterctl
 
 # Init the cluster
 clusterctl init --core cluster-api:v1.1.5 --bootstrap kubeadm:v1.1.5 --control-plane kubeadm:v1.1.5 --infrastructure=metal3:v1.1.2  -v5
+
+# Download the node image
+sudo ./dowanload-node-image.sh
+
 # Apply clusters template
-sleep 30
+sleep 90
 kubectl apply -f test1-manifests/cluster-template.yaml -n test1
 kubectl apply -f test2-manifests/cluster-template.yaml -n test2
 kubectl apply -f test1-manifests/controlplane-template.yaml -n test1

--- a/Support/Multitenancy/Ironic_bmo-mult-instances/clean.sh
+++ b/Support/Multitenancy/Ironic_bmo-mult-instances/clean.sh
@@ -1,0 +1,33 @@
+sudo virsh undefine node-1
+sudo virsh undefine node-2
+
+sudo nmcli con delete baremetal
+sudo nmcli con delete provisioning-1
+sudo nmcli con delete provisioning-2
+
+sudo virsh net-undefine provisioning-2
+sudo virsh net-undefine provisioning-1
+sudo virsh net-undefine baremetal
+
+sudo virsh net-destroy baremetal
+sudo virsh net-destroy  provisioning-2
+sudo virsh net-destroy provisioning-1
+
+sudo ip link set provisioning-2 down
+sudo ip link set provisioning-1 down
+sudo ip link set baremetal down
+sudo brctl delbr baremetal
+sudo brctl delbr provisioning-1
+sudo brctl delbr provisioning-2
+sudo virsh vol-delete --pool  mypool node-1.qcow2
+sudo virsh vol-delete --pool  mypool node-2.qcow2
+sudo virsh pool-destroy mypool
+sudo virsh pool-undefine mypool
+sudo rm -rf  /opt/mypool
+#sudo rm -rf /opt/metal3-dev-env
+sudo rm -rf /opt/metal3-dev-env/ironic/virtualbmc/
+sudo podman stop -a
+sudo podman rmi $(sudo podman images -qa) -f
+
+minikube stop
+minikube delete --all --purge

--- a/Support/Multitenancy/Ironic_bmo-mult-instances/dowanload-node-image.sh
+++ b/Support/Multitenancy/Ironic_bmo-mult-instances/dowanload-node-image.sh
@@ -1,0 +1,5 @@
+cd /opt/metal3-dev-env/ironic/html/images/
+wget https://artifactory.nordix.org/artifactory/metal3/images/k8s_v1.24.1/CENTOS_9_NODE_IMAGE_K8S_v1.24.1.qcow2
+qemu-img convert -O raw CENTOS_9_NODE_IMAGE_K8S_v1.24.1.qcow2 CENTOS_9_NODE_IMAGE_K8S_v1.24.1-raw.img
+md5sum CENTOS_9_NODE_IMAGE_K8S_v1.24.1-raw.img | awk '{print $1}' > CENTOS_9_NODE_IMAGE_K8S_v1.24.1-raw.img.md5sum
+cd -


### PR DESCRIPTION
- Change network config to keyfile format
- The recent libvirt package fails to create a domain with `nvram`
- Increase the waiting time before applying the cluster template
- Add download node image script
- Add cleanup script