### PR TITLE
security: add Kubelogin POC

### DIFF
--- a/security/kubelogin-poc/README.md
+++ b/security/kubelogin-poc/README.md
@@ -1,0 +1,196 @@
+# kuberos/kubelogin poc
+
+<!-- markdownlint-disable MD013 -->
+
+## Kubelogin, or kubectl-oidc_login
+
+Docs:
+
+- <https://github.com/int128/kubelogin>
+- <https://github.com/int128/kubelogin/blob/master/docs/usage.md>
+
+### Kubelogin installation
+
+Get the binary from
+[releases](https://github.com/int128/kubelogin/releases/tag/v1.28.0), and
+install as `kubectl-oidc_login` in `/usr/local/bin` or elsewhere in `$PATH`.
+
+## Grant types
+
+Kubelogin and Dex support following grant types:
+
+- auto (automatic selection)
+- authcode (token passthru via web browser callback)
+- authcode-keyboard (generates code you need to paste yourself)
+- device-code (like authcode, but for a device of certain code)
+- password (supply username and password on the command line, not enabled by default)
+
+Grant type is specified with `--grant-type=<type>` on command line during setup.
+
+### Authcode
+
+Authcode is the default mode, where it brings up the browser and then after
+successful login it calls the callback to pass the token to kubelogin.
+
+Triggering it on a headless machine is problematic. You can workaround it by
+creating SSH forwarding from your desktop machine and that way circumvent the
+headless limitation.
+
+```console
+$ ssh -L 8000:127.0.0.1:8000 <host>
+...
+$ kubectl oidc-login setup \
+    --oidc-issuer-url=http://127.0.0.1:5556/dex \
+    --oidc-client-id=kubelogin-test \
+    --oidc-client-secret=kubelogin-test-secret
+
+authentication in progress...
+error: could not open the browser: exec: "xdg-open,x-www-browser,www-browser": executable file not found in $PATH
+
+Please visit the following URL in your browser manually: http://localhost:8000
+```
+
+### Authocde-Keyboard
+
+```console
+$ kubectl oidc-login setup --oidc-issuer-url=http://127.0.0.1:5556/dex \
+    --oidc-client-id=kubelogin-test --oidc-client-secret=kubelogin-test-secret \
+    --grant-type=authcode-keyboard
+authentication in progress...
+Please visit the following URL in your browser: http://127.0.0.1:5556/dex/auth?access_type=offline&client_id=kubelogin-test&code_challenge=86dPTBNva5aIaXvewKOSyw7P-URcw3Ap8SHtTnhBviA&code_challenge_method=S256&nonce=-Fep0vXzWv48P_u6Jk6BsuQhguRNMzCGByQnCpZ6JnQ&redirect_uri=urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob&response_type=code&scope=openid&state=IRBxjcXHgcTz-IA8ws_045ktOSozc4s1ixj-ykNWyJ0
+Enter code:
+```
+
+Then you access that URL, and you get code like `b2ifzli5rdb3lsahxaqxxtklr`,
+which you can enter into the prompt. Requires browser.
+
+### Device-code
+
+Device code seems to be the same as AuthCode, except you need to enter the
+device-code for the device you're identifying for. Requires browser.
+
+### Password
+
+Password flow is enabled only, if Dex config is set to allow it by setting one
+of the connectors as `passwordConnector`:
+
+```yaml
+oauth2:
+  passwordConnector: ldap
+```
+
+If this config is not present, password grant type is rejected as
+`not supported`. Most of the connectors do not support username/password.
+`local` and `ldap` do.
+
+## Putting it all together
+
+Now that we know we can do `kubelogin` -> `Dex` -> `openLDAP`, we need to
+setup the final chain, where Dex is integrated with k8s apiserver, and it
+actually authenticates `kubectl` commands via Dex.
+
+### Kind setup
+
+Setup Kind cluster with additional config in [kind.conf](k8s/kind.conf).
+
+Run: `kind create cluster --config=kind.conf`
+
+Make note of the `extraArgs` as they define fields how users and groups are
+identified and they need to match ClusterRoles created, otherwise the logged in
+users won't have any rights.
+
+For Kind setup, we also need to mount a directory holding a Dex generated CA
+cert, so apiserver will trust the Dex when connecting. Using [Dex's certificate
+generation script](https://github.com/dexidp/dex/blob/master/examples/k8s/gencert.sh),
+you get a CA cert, which should be mounted via directory
+`/etc/ssl/certs/dex-test` in the apiserver.
+
+### Dex setup
+
+We setup Dex to run in nodeport `32000` so it is reachable by the apiserver and
+the user's kubectl client. Alternatively, Dex could be configued with service
+andpoint, and apiserver could be configured to connect to `dex.dex` for example.
+OIDC provider is often external to the cluster, and hence the nodeport simulates
+reality better than in-cluster service.
+
+For Dex, we also add LDAP connector configuration and set `passwordConnector` to
+`ldap`.
+
+You also need to input key and certificate from `gencert.sh` into
+`dex.example.com.tls` Secret for this test setup. These certs must be same as
+the generated CA certificate in previous step. Using expired or non-trusted
+certificates causes apiserver not trust Dex, and login attempts will fail even
+if the Dex token kubectl gained is valid.
+
+See [dex.yaml](k8s/dex.yaml).
+
+We also need to add a line to `/etc/hosts` to create fake Dex domain:
+`127.0.0.1       dex.example.com` or simply change all occurences of
+`dex.example.com` with `127.0.0.1`. Here we use the `dex.example.com` in order
+to make a difference between Dex host and other services.
+
+### OpenLDAP k8s setup
+
+We need to set up OpenLDAP so it is reachable by Dex. In this setup, we run it
+via service `openldap.openldap`, but also expose it via nodeport `31389` for
+debugging purposes.
+
+See [openldap.yaml](k8s/openldap.yaml).
+
+For reference, see [contents](k8s/openldap.txt) of openLDAP test database.
+
+### Setup kubectl
+
+Now we have technically everything in place, so let's advise kubectl
+to log us in.
+
+We then set login credentials for user alias `oidc`. Here we have
+`--insecure-skip-tls-verify` since it is a test setup and no proper TLS certs
+are configured on the test host.
+
+```console
+    kubectl config set-credentials oidc \
+      --exec-api-version=client.authentication.k8s.io/v1beta1 \
+      --exec-command=kubectl \
+      --exec-arg=oidc-login \
+      --exec-arg=get-token \
+      --exec-arg=--oidc-issuer-url=https://dex.example.com:32000 \
+      --exec-arg=--oidc-client-id=kubelogin-test \
+      --exec-arg=--oidc-client-secret=kubelogin-test-secret \
+      --exec-arg=--oidc-extra-scope=email \
+      --exec-arg=--oidc-extra-scope=profile \
+      --exec-arg=--oidc-extra-scope=groups \
+      --exec-arg=--grant-type=password \
+      --exec-arg=--insecure-skip-tls-verify
+```
+
+and kubeconfig ends up looking like [this](k8s/kubeconfig).
+
+#### Cluster roles
+
+Cluster role needs to be assigned based on the username or the groups passed via
+the `groups` scope. These roles need to be configured by the pre-existing
+cluster admin, otherwise users logging in via Dex won't have any permissions.
+
+```yaml
+kubectl create clusterrolebinding oidc-cluster-admin \
+  --clusterrole=cluster-admin \  # whatever the role should be
+  --user='Bar1'  # whatever the username-claim=email field defines username field is
+```
+
+or better, you should configure group claim so each individual user does not
+need separate role configured:
+
+```yaml
+kubectl create clusterrolebinding oidc-cluster-admin-group \
+  --clusterrole=cluster-admin \  # whatever the role should be
+  --group='readers'  # whatever the group-claim=groups field defines groups field is
+```
+
+LDAP configuration would be different per organization regardless.
+
+Some references:
+
+- <https://dexidp.io/docs/connectors/oidc/>
+- <https://openid.net/specs/openid-connect-core-1_0.html#Claims>
+- <https://dexidp.io/docs/custom-scopes-claims-clients/>

--- a/security/kubelogin-poc/k8s/config.yaml
+++ b/security/kubelogin-poc/k8s/config.yaml
@@ -1,0 +1,125 @@
+issuer: http://127.0.0.1:5556/dex
+
+storage:
+  type: sqlite3
+  config:
+    file: dex.db
+
+web:
+  http: 127.0.0.1:5556
+
+telemetry:
+  http: 127.0.0.1:5558
+
+grpc:
+  addr: 127.0.0.1:5557
+
+staticClients:
+- id: kubelogin-test
+  name: Kubernetes
+  redirectURIs:
+  - urn:ietf:wg:oauth:2.0:oob
+  - http://localhost:8000
+  - http://localhost:18000
+  - /device/callback
+  secret: kubelogin-test-secret
+
+connectors:
+- type: ldap
+  # Required field for connector id.
+  id: ldap
+  # Required field for connector name.
+  name: LDAP
+  config:
+    # Host and optional port of the LDAP server in the form "host:port".
+    # If the port is not supplied, it will be guessed based on "insecureNoSSL",
+    # and "startTLS" flags. 389 for insecure or StartTLS connections, 636
+    # otherwise.
+    host: 127.0.0.1:1389
+
+    # Following field is required if the LDAP host is not using TLS (port 389).
+    # Because this option inherently leaks passwords to anyone on the same network
+    # as dex, THIS OPTION MAY BE REMOVED WITHOUT WARNING IN A FUTURE RELEASE.
+    #
+    insecureNoSSL: true
+
+    # If a custom certificate isn't provide, this option can be used to turn on
+    # TLS certificate checks. As noted, it is insecure and shouldn't be used outside
+    # of explorative phases.
+    #
+    # insecureSkipVerify: true
+
+    # When connecting to the server, connect using the ldap:// protocol then issue
+    # a StartTLS command. If unspecified, connections will use the ldaps:// protocol
+    #
+    # startTLS: true
+
+    # Path to a trusted root certificate file. Default: use the host's root CA.
+    # rootCA: /etc/dex/ldap.ca
+
+    # A raw certificate file can also be provided inline.
+    # rootCAData: ( base64 encoded PEM file )
+
+    # The DN and password for an application service account. The connector uses
+    # these credentials to search for users and groups. Not required if the LDAP
+    # server provides access for anonymous auth.
+    # Please note that if the bind password contains a `$`, it has to be saved in an
+    # environment variable which should be given as the value to `bindPW`.
+    # bindDN: uid=serviceaccount,cn=users,dc=example,dc=com
+    bindDN: cn=admin,dc=example,dc=org
+    bindPW: adminpassword
+
+    # The attribute to display in the provided password prompt. If unset, will
+    # display "Username"
+    usernamePrompt: SSO Username
+
+    # User search maps a username and password entered by a user to a LDAP entry.
+    userSearch:
+      # BaseDN to start the search from. It will translate to the query
+      # "(&(objectClass=person)(uid=<username>))".
+      baseDN: dc=example,dc=org
+      # Optional filter to apply when searching the directory.
+      # filter: "(objectClass=person)"
+
+      # username attribute used for comparing user entries. This will be translated
+      # and combined with the other filter as "(<attr>=<username>)".
+      username: uid
+      # The following three fields are direct mappings of attributes on the user entry.
+      # String representation of the user.
+      idAttr: uidNumber
+      # Required. Attribute to map to Email.
+      emailAttr: sn  # email
+      # Maps to display name of users. No default value.
+      nameAttr: cn
+      # Maps to preferred username of users. No default value.
+      preferredUsernameAttr: uid
+
+    # Group search queries for groups given a user entry.
+    groupSearch:
+      # BaseDN to start the search from. It will translate to the query
+      # "(&(objectClass=group)(member=<user uid>))".
+      baseDN: cn=groups,dc=example,dc=org
+      # Optional filter to apply when searching the directory.
+      filter: "(objectClass=group)"
+
+      # Following list contains field pairs that are used to match a user to a group. It adds an additional
+      # requirement to the filter that an attribute in the group must match the user's
+      # attribute value.
+      userMatchers:
+      - userAttr: uid
+        groupAttr: member
+
+      # Represents group name.
+      nameAttr: name
+
+oauth2:
+  passwordConnector: ldap
+
+enablePasswordDB: true
+
+staticPasswords:
+  - email: "admin@example.com"
+    hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+    username: "admin"
+    userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
+

--- a/security/kubelogin-poc/k8s/dex.yaml
+++ b/security/kubelogin-poc/k8s/dex.yaml
@@ -1,0 +1,294 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dex
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: dex
+  name: dex
+  namespace: dex
+spec:
+  replicas: 1 # 3 normally, 1 for testing
+  selector:
+    matchLabels:
+      app: dex
+  template:
+    metadata:
+      labels:
+        app: dex
+    spec:
+      serviceAccountName: dex
+      containers:
+      - image: ghcr.io/dexidp/dex:v2.32.0
+        name: dex
+        command: ["/usr/local/bin/dex", "serve", "/etc/dex/cfg/config.yaml"]
+
+        ports:
+        - name: https
+          containerPort: 5556
+
+        volumeMounts:
+        - name: config
+          mountPath: /etc/dex/cfg
+        - name: tls
+          mountPath: /etc/dex/tls
+
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 5556
+            scheme: HTTPS
+      volumes:
+      - name: config
+        configMap:
+          name: dex
+          items:
+          - key: config.yaml
+            path: config.yaml
+      - name: tls
+        secret:
+          secretName: dex.example.com.tls
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: dex
+  namespace: dex
+data:
+  config.yaml: |
+    issuer: https://dex.example.com:32000
+    storage:
+      type: kubernetes
+      config:
+        inCluster: true
+    web:
+      https: 0.0.0.0:5556
+      tlsCert: /etc/dex/tls/tls.crt
+      tlsKey: /etc/dex/tls/tls.key
+    connectors:
+    - type: ldap
+      # Required field for connector id.
+      id: ldap
+      # Required field for connector name.
+      name: LDAP
+      config:
+        # Host and optional port of the LDAP server in the form "host:port".
+        # If the port is not supplied, it will be guessed based on "insecureNoSSL",
+        # and "startTLS" flags. 389 for insecure or StartTLS connections, 636
+        # otherwise.
+
+        # openLDAP is running in svc network on port 1389 in this testing setup
+        host: openldap.openldap:1389
+
+        # Following field is required if the LDAP host is not using TLS (port 389).
+        # Because this option inherently leaks passwords to anyone on the same network
+        # as dex, THIS OPTION MAY BE REMOVED WITHOUT WARNING IN A FUTURE RELEASE.
+        #
+        # openLDAP is running without TLS in this testing setup
+        insecureNoSSL: true
+
+        # If a custom certificate isn't provide, this option can be used to turn on
+        # TLS certificate checks. As noted, it is insecure and shouldn't be used outside
+        # of explorative phases.
+        #
+        # insecureSkipVerify: true
+
+        # When connecting to the server, connect using the ldap:// protocol then issue
+        # a StartTLS command. If unspecified, connections will use the ldaps:// protocol
+        #
+        # startTLS: true
+
+        # Path to a trusted root certificate file. Default: use the host's root CA.
+        # we don't use custom CA for this
+        # rootCA: /etc/dex/ldap.ca
+
+        # A raw certificate file can also be provided inline.
+        # rootCAData: ( base64 encoded PEM file )
+
+        # The DN and password for an application service account. The connector uses
+        # these credentials to search for users and groups. Not required if the LDAP
+        # server provides access for anonymous auth.
+        # Please note that if the bind password contains a `$`, it has to be saved in an
+        # environment variable which should be given as the value to `bindPW`.
+        #
+        # openLDAP testing admin creds, although read-only creds recommended
+        bindDN: cn=admin,dc=example,dc=org
+        bindPW: adminpassword
+
+        # The attribute to display in the provided password prompt. If unset, will
+        # display "Username"
+        # usernamePrompt: SSO Username
+
+        # User search maps a username and password entered by a user to a LDAP entry.
+        #
+        # This LDAP configuration needs to match the LDAP/AD config used in production
+        # It should be noted that if the groupSearch config is invalid, the user is
+        # not able to login, even if username/password would be correct as the token
+        # generation will fail!
+        userSearch:
+          # BaseDN to start the search from. It will translate to the query
+          # "(&(objectClass=person)(uid=<username>))".
+          baseDN: dc=example,dc=org
+          # Optional filter to apply when searching the directory.
+          # filter: "(objectClass=person)"
+
+          # username attribute used for comparing user entries. This will be translated
+          # and combined with the other filter as "(<attr>=<username>)".
+          username: uid
+          # The following three fields are direct mappings of attributes on the user entry.
+          # String representation of the user.
+          idAttr: uidNumber
+          # Required. Attribute to map to Email.
+          emailAttr: sn  # email is not available in openLDAP test server
+          # Maps to display name of users. No default value.
+          nameAttr: cn
+          # Maps to preferred username of users. No default value.
+          preferredUsernameAttr: uid
+
+        # Group search queries for groups given a user entry.
+        groupSearch:
+          # BaseDN to start the search from. It will translate to the query
+          # "(&(objectClass=group)(member=<user uid>))".
+          baseDN: ou=users,dc=example,dc=org
+          # Optional filter to apply when searching the directory.
+          filter: "(objectClass=groupOfNames)"
+
+          # Following list contains field pairs that are used to match a user to a group. It adds an additional
+          # requirement to the filter that an attribute in the group must match the user's
+          # attribute value.
+          userMatchers:
+          - userAttr: dn
+            groupAttr: member
+
+          # Represents group name.
+          nameAttr: cn
+
+    oauth2:
+      passwordConnector: ldap
+      # Password grant type does not have approval screen, but could be useful
+      # for other grant types to avoid an extra click in the browser
+      # skipApprovalScreen: true
+
+    staticClients:
+    - id: kubelogin-test
+      name: Kubernetes
+      # none of the redirect uris are needed for password grant type
+      # they're listed here as needed for testing other grant types
+      redirectURIs:
+      - urn:ietf:wg:oauth:2.0:oob
+      - http://localhost:8000
+      - http://localhost:18000
+      - /device/callback
+      secret: kubelogin-test-secret
+
+    enablePasswordDB: true
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dex
+  namespace: dex
+spec:
+  type: NodePort
+  ports:
+  - name: dex
+    port: 5556
+    protocol: TCP
+    targetPort: 5556
+    nodePort: 32000
+  selector:
+    app: dex
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: dex
+  name: dex
+  namespace: dex
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dex
+rules:
+- apiGroups: ["dex.coreos.com"] # API group created by dex
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["create"] # To manage its own resources, dex must be able to create customresourcedefinitions
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dex
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dex
+subjects:
+- kind: ServiceAccount
+  name: dex # Service account assigned to the dex pod, created above
+  namespace: dex # The namespace dex is running in
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dex.example.com.tls
+  namespace: dex
+type: kubernetes.io/tls
+stringData:
+  # these certificates can be generated by using the Dex's gencert.sh
+  tls.crt: |
+    -----BEGIN CERTIFICATE-----
+    MIIDKDCCAhCgAwIBAgIUZuNp2ziatARk1NlOhJXitIuFiAIwDQYJKoZIhvcNAQEL
+    BQAwEjEQMA4GA1UEAwwHa3ViZS1jYTAeFw0yMzEwMTIwODUxNTFaFw0yMzEwMjIw
+    ODUxNTFaMBIxEDAOBgNVBAMMB2t1YmUtY2EwggEiMA0GCSqGSIb3DQEBAQUAA4IB
+    DwAwggEKAoIBAQC2RlTidTfEjtEsqrIPtunNA/iYnzZ7aZDNVmWB5hkRhE0J/gyl
+    58PoPuSwT3nn11QLvQn9wE0EuLGQOu1n5YuJ1VlxNAjcz9WQHpMhIk6bwbHsMuv/
+    6uOs8qPyrhWk5wS3oRNY3bJdyRkwdGv5txgTIjsNBGv7N7UYtxoC5KnTDssJV7jM
+    7jK9VGS2uqp4dDUlPpGoMGJzxD33Kjc9hGVdmr2vjYVDp5sE++xeMTCRE1cnZXRQ
+    hE5E15vEVkuSmOUaZcDLNmqKTg1v3pVARLNKRZbtHeYbaDIYwE96fh1v6gS1f8xN
+    ouCYGlVUsfo05/NMUEARA3LDnHqIQzHjrwFLAgMBAAGjdjB0MAkGA1UdEwQCMAAw
+    CwYDVR0PBAQDAgXgMBoGA1UdEQQTMBGCD2RleC5leGFtcGxlLmNvbTAdBgNVHQ4E
+    FgQU/Y+ymdtnSTUDJ76N6fw6VJHft/QwHwYDVR0jBBgwFoAU4JGqsUcWuSojjCpZ
+    HJUzyM4tY3QwDQYJKoZIhvcNAQELBQADggEBAC6zGncezPoIv9V3edj4PaVWGiP7
+    pZocf5RSdLgotDu18DAaMTxeSQ8pTEE4DtLIJqzz8PXRjmwqF0sz+y40eqnL6EXV
+    6LiJDPqDdiB/SqjD1dHeJ4IROWDAuB28bxFRT70yE3iBoHHg1f+dsCkfm8VvlAyR
+    eS3E9mtsAHsrlh/iyhceaM1JgcIc8skKn6GUZJEWRAvOBX5NnAMTrHNyHGop8k9+
+    vqJmhbGUnCFg2KuMwmJXZ4FXpU60UaU1l3daaAuZ94tfaY1KovmaeopNNvoUNglY
+    5nHWvfcx5m/H1L58Zz0PmksmOBK+yEr6qb6Ohd6AbstNjuRyYvAKNXARv5w=
+    -----END CERTIFICATE-----
+  tls.key: |
+    -----BEGIN PRIVATE KEY-----
+    MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC2RlTidTfEjtEs
+    qrIPtunNA/iYnzZ7aZDNVmWB5hkRhE0J/gyl58PoPuSwT3nn11QLvQn9wE0EuLGQ
+    Ou1n5YuJ1VlxNAjcz9WQHpMhIk6bwbHsMuv/6uOs8qPyrhWk5wS3oRNY3bJdyRkw
+    dGv5txgTIjsNBGv7N7UYtxoC5KnTDssJV7jM7jK9VGS2uqp4dDUlPpGoMGJzxD33
+    Kjc9hGVdmr2vjYVDp5sE++xeMTCRE1cnZXRQhE5E15vEVkuSmOUaZcDLNmqKTg1v
+    3pVARLNKRZbtHeYbaDIYwE96fh1v6gS1f8xNouCYGlVUsfo05/NMUEARA3LDnHqI
+    QzHjrwFLAgMBAAECggEAETRP6coU7Uq/p/QlTMIVN60oHJvBLuKMG4g2mjgHkLWI
+    of373/hMGlKUD6eIwvR6RzCyIznbQIFVp96aru5QfpOH1t1e+ByZNKULem/8XyDo
+    CXqATQ5fgWEA+YnV8CkqsvxopkAoCEh6xgM5zSmrg47SZ7b4TDokr+8EbQEmnbhE
+    VIkqhTJDs1Es+y+hOIut3rbrkwsnJqg98FWpAmavgen6P/m5I2vN2Cc2gb+ht3UT
+    5akCTyTEUYNy8+EOZ8fpdAW6Z+6Uo/0W+S1N1RkLwDO/IAgzsLcaQNxSMSNQG08/
+    x40Z7HKLCTM0jWvvyTbCq4mZkfiwGpCHT2w74vdSrQKBgQDpfli76xUXie6Q3Dqk
+    eT0FvcE2Xtc95hcwT1DKjS9zIGf96iIGdbQNMkVRu7Ovu0rrIYSdfQy1xbuYcBa8
+    qEALKldkO5jFj/5z/puEorOUnO7w2N/0TEzk0zJ/hGgQKF5LdJ3wvDkUhEt41LDF
+    iwvIflmJzFq5hyE0IW67qmjGNQKBgQDH2B3vOxxB63ucereSm85qeorURteH9Dfn
+    Dd9syGchvOYY9uWKonVP7UevmQcvcO32zeGrCpo8hVOoCMTOShBnf1gAhXMQNAF3
+    XyNA2ognCJJRsM7iy+97wyIgb5XGtM7Pz0BOUcPC/0OnHz9PFqNmGokH2wU3NxbR
+    gVQGWiOZfwKBgQCyOWaxybbHyNj4aaG5eXFCuJyKS8ovzTlV/rTEZxAY6Ft4TQa7
+    t4w/pmeTA5scP/HnmCYJsDHLbarLqIMybZq06xTZxUPPSSIImAdNLoO0pDUeUexg
+    JP1sjGi3PPHRo36WSeVko8dOCc0x5ecoYgIUf50IuZtmkeaeTAah6GkhIQKBgQCG
+    QlZSC5c/XjHsfbFoqI4zkOJGHNXd+5+29eX9kmFfFCZN7UlnKx+/M70uZpOiNq9Y
+    WRbcL0JRmI0MXd/Ca5W7wpzftMgJwbaeeOcZQfeoqaSLh0pmqfXZYs5BllW8ampq
+    yGT+eQYYsh/EXkTNIHtkND2NboKBhtwookdOAS7bhwKBgCQJko7tB/g4GQAMyVoP
+    WuSowvJJipaVv0VWUoD/ExNOsCOkJm9wqJxQAjA5ClZR9y+pxsbTlQHIuraKzvMn
+    Azu2odRFQzbeZr773TRfe/rIEQt/Co8NJH8ilolIOfFidMUkZKZKYCb93MFNpye+
+    wH9SvJ4kz/jzHkw+z87xnkFz
+    -----END PRIVATE KEY-----

--- a/security/kubelogin-poc/k8s/kind.conf
+++ b/security/kubelogin-poc/k8s/kind.conf
@@ -1,0 +1,27 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  # test setup related mount to get the Dex CA cert available to apiserver
+  extraMounts:
+  - hostPath: /etc/ssl/certs/dex-test
+    containerPath: /etc/ssl/certs/dex-test
+    readOnly: true
+  # test setup related port maps: 32000 for Dex to be available locally
+  # and 31389 for the openldap to be available locally (only for debug)
+  extraPortMappings:
+  - containerPort: 32000
+    hostPort: 32000
+  - containerPort: 31389
+    hostPort: 31389
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+        extraArgs:
+            oidc-issuer-url: https://dex.example.com:32000
+            oidc-client-id: kubelogin-test
+            oidc-ca-file: /etc/ssl/certs/dex-test/dex-ca-test.pem
+            oidc-username-claim: email
+            # group-claim: cn is test related as well, normally it would say "groups"
+            oidc-groups-claim: cn

--- a/security/kubelogin-poc/k8s/kubeconfig
+++ b/security/kubelogin-poc/k8s/kubeconfig
@@ -1,0 +1,38 @@
+apiVersion: v1
+# regular cluster configuration here
+clusters:
+- cluster:
+    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUMvakNDQWVhZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJek1UQXhNakV4TkRjeE1Wb1hEVE16TVRBd09URXhORGN4TVZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTXZSCmV6OXRHdk83czlaMlNEbVY3c2VOTzVJTHhjNjExUkpEUUlnWExLVzFzaHoyU1RRMm44K2F5dXFzR2lhb1JaQ1cKdlNiRGFVeTFDM1RXeHd6a21YWFdITTMzN0ZENjlEVGhBaEsrYjR0TmpubmJwL3JSYzU1UE5zRVdRckFxbXMwdgpXVW5URDNVOVYzTDdFbDdFWUJhdlhsWmVGd25ZK0JKYmkxQ3VDTldkL2paWXBvcjVOSTlSdXI1QjJlZGZ5cVRVCnJtSTFOa1hqTE9FaHc4ZjVtR1VYOTJSaHlxbzdlUC8wSnFrdEczdjgwMUd1NXVJZE5VUVNrcm5lc1Y4djZkUDgKZEpiUnlpMWNMMTRGN29zL1JlVGpObHlLc2UwMGlpMm14ZWM4UnMzN0p5TGJobGNERkpZS3JaalV3QXM0anV5agp2c29ueTFuQ0NJeU5SK3B5RDRzQ0F3RUFBYU5aTUZjd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZQcEs0S0VyekxGMmZKWktpWUJ3S3BrUitFdDdNQlVHQTFVZEVRUU8KTUF5Q0NtdDFZbVZ5Ym1WMFpYTXdEUVlKS29aSWh2Y05BUUVMQlFBRGdnRUJBRDVIbUZlSS9EN1daWmNMaytQdAplM3RBb01CMGlxVkd5UG54YTJxWVIrS3JpU1F6U0FJbDBkejZpdURrdE1MM2wvVEZmc0UzaUxFSmI3STBQWlU5CmNQeXptckdjQnI0T1FlQndNalIvc0lPN0VzN1ZhdElWS3l1UDIzY25OUE1pSjFNbWxtTWRjOTNJWXM0Q04zT2EKbk5DblBsNi9lNUNaNnlvVTMvSXJTM0dZSVorcmQ5alk5ZkRWVzFyTklWejVkQTZuclJwb2VOT3BxcTRCVDJKMQo1empHc1Rhc1NmNGljZmpad0ZleStSbTlSMGQ0WEpzRUtVMW5oMFpoT1V6L1phMlpCb29VWlBpbFhRemRwQnBnCmFpK1Z3eDJXNDVUSFY4K2F1L2xVclVXbnhNVm94QXFWV0NuNWNHNWlmT0RCRzhiY3JnbXFIMElhNlVKeXpNUm0KNGJzPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+    server: https://127.0.0.1:42019
+  name: kind-kind
+contexts:
+- context:
+    cluster: kind-kind
+    user: oidc
+  name: kind-oidc
+current-context: kind-oidc
+kind: Config
+preferences: {}
+users:
+# in user section, use whatever user name you want, but the oidc-login setup
+# needs to match the OIDC config passed to the apiserver
+# insecure-skip-tls-verify is only here because of the test setup
+# issuer url needs to be accessible and match the Dex issuer config
+- name: oidc
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
+      args:
+      - oidc-login
+      - get-token
+      - --oidc-issuer-url=https://dex.example.com:32000
+      - --oidc-client-id=kubelogin-test
+      - --oidc-client-secret=kubelogin-test-secret
+      - --oidc-extra-scope=email
+      - --oidc-extra-scope=profile
+      - --oidc-extra-scope=groups
+      - --grant-type=password
+      - --insecure-skip-tls-verify
+      command: kubectl
+      env: null
+      provideClusterInfo: false

--- a/security/kubelogin-poc/k8s/openldap.txt
+++ b/security/kubelogin-poc/k8s/openldap.txt
@@ -1,0 +1,43 @@
+$ ldapsearch -H ldap://127.0.0.1:1389 -x -b "dc=example,dc=org" -D "cn=admin,dc=example,dc=org" -w adminpassword -LLL "objectclass=*"
+
+dn: dc=example,dc=org
+objectClass: dcObject
+objectClass: organization
+dc: example
+o: example
+
+dn: ou=users,dc=example,dc=org
+objectClass: organizationalUnit
+ou: users
+
+dn: cn=customuser,ou=users,dc=example,dc=org
+cn: User1
+cn: customuser
+sn: Bar1
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: shadowAccount
+userPassword:: Y3VzdG9tcGFzc3dvcmQ=
+uid: customuser
+uidNumber: 1000
+gidNumber: 1000
+homeDirectory: /home/customuser
+
+dn: cn=foo,ou=users,dc=example,dc=org
+cn: User2
+cn: foo
+sn: Bar2
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: shadowAccount
+userPassword:: YmFy
+uid: foo
+uidNumber: 1001
+gidNumber: 1001
+homeDirectory: /home/foo
+
+dn: cn=readers,ou=users,dc=example,dc=org
+cn: readers
+objectClass: groupOfNames
+member: cn=customuser,ou=users,dc=example,dc=org
+member: cn=foo,ou=users,dc=example,dc=org

--- a/security/kubelogin-poc/k8s/openldap.yaml
+++ b/security/kubelogin-poc/k8s/openldap.yaml
@@ -1,0 +1,59 @@
+# we make it serve in nodeport 31389
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openldap
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: openldap
+  name: openldap
+  namespace: openldap
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: openldap
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: openldap
+    spec:
+      containers:
+      - image: bitnami/openldap:latest
+        name: openldap
+        env:
+        - name: LDAP_ADMIN_USERNAME
+          value: admin
+        - name: LDAP_ADMIN_PASSWORD
+          value: adminpassword
+        - name: LDAP_USERS
+          value: customuser,foo
+        - name: LDAP_PASSWORDS
+          value: custompassword,bar
+        - name: LDAP_ROOT
+          value: dc=example,dc=org
+        - name: LDAP_ADMIN_DN
+          value: cn=admin,dc=example,dc=org
+status: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: openldap
+  namespace: openldap
+spec:
+  type: NodePort
+  ports:
+  - name: openldap
+    port: 1389
+    protocol: TCP
+    targetPort: 1389
+    nodePort: 31389
+  selector:
+    app: openldap


### PR DESCRIPTION
This POC is about enabling `int128/kubelogin`, ie. `kubectl-oidc_login` integration to k8s apiserver, while running Dex as OIDC provider backed by (open)LDAP. k8s cluster provided by Kind.