### PR TITLE
switch markdownlint container to markdownlint-cli2

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,11 @@
+# Reference: https://github.com/DavidAnson/markdownlint-cli2#markdownlint-cli2yaml
+# TODO: Fix line length issues later
+
+config:
+  ul-indent:
+    # Kramdown wanted us to have 3 earlier, tho this CLI recommends 2 or 4
+    indent: 3
+  line-length: false
+
+# Don't autofix anything, we're linting here
+fix: false

--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -1,34 +1,20 @@
-#!/usr/bin/env bash
-
-# TODO:
-# Fix the markdownlint complaints
-#
-# Further documentation is available for these failures:
-#  - MD013: https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md013---line-length
-#  - MD029: https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md029---ordered-list-item-prefix
-#  - MD056: https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md056---table-has-inconsistent-number-of-columns
-#  - MD055: https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md055---table-row-doesn-t-begin-end-with-pipes
-#  - MD057: https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md057---table-has-missing-or-invalid-header-separation-second-row-
+#!/bin/sh
+# markdownlint-cli2 has config file(s) named .markdownlint-cli2.yaml in the repo
 
 set -eux
 
-IS_CONTAINER=${IS_CONTAINER:-false}
+IS_CONTAINER="${IS_CONTAINER:-false}"
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 
+# all md files, but ignore .github
 if [ "${IS_CONTAINER}" != "false" ]; then
-  TOP_DIR="${1:-.}"
-  find "${TOP_DIR}" \
-      \( -path ./vendor -o -path ./.github \) \
-      -prune -o -name '*.md' -exec \
-      mdl --style all --warnings \
-      --rules "~MD013,~MD029,~MD055,~MD056,~MD057" \
-      {} \+
+    markdownlint-cli2 "**/*.md" "#.github"
 else
-  "${CONTAINER_RUNTIME}" run --rm \
-    --env IS_CONTAINER=TRUE \
-    --volume "${PWD}:/workdir:ro,z" \
-    --entrypoint sh \
-    --workdir /workdir \
-    docker.io/pipelinecomponents/markdownlint:0.13.0@sha256:9c0cdfb64fd3f1d3bdc5181629b39c2e43b6a52fc9fdc146611e1860845bbae0 \
-    /workdir/hack/markdownlint.sh "$@"
+    "${CONTAINER_RUNTIME}" run --rm \
+        --env IS_CONTAINER=TRUE \
+        --volume "${PWD}:/workdir:ro,z" \
+        --entrypoint sh \
+        --workdir /workdir \
+        docker.io/pipelinecomponents/markdownlint-cli2:0.9.0@sha256:71370df6c967bae548b0bfd0ae313ddf44bfad87da76f88180eff55c6264098c \
+        /workdir/hack/markdownlint.sh "$@"
 fi


### PR DESCRIPTION
Switch markdownlint container to markdownlint-cli2. This CLI version supports the enable/disable rules in markdown files and allows us to ignore issues locally, not just globally.

- project-infra PR https://github.com/metal3-io/project-infra/pull/619 needs to merge for markdownlint here to pass
