### PR TITLE
add keylime-poc part 1: docker compose and agent with swtpm

### DIFF
--- a/security/keylime-poc/README.md
+++ b/security/keylime-poc/README.md
@@ -1,0 +1,8 @@
+# Keylime POC
+<!-- cSpell:ignore keylime -->
+
+## Docker Compose
+
+First part of POC is deploying Keylime services in
+[Docker Compose](compose/README.md). Setup is verified by a single Agent, backed
+by software TPM, also in Docker.

--- a/security/keylime-poc/agent-with-swtpm/Dockerfile
+++ b/security/keylime-poc/agent-with-swtpm/Dockerfile
@@ -1,0 +1,85 @@
+##############################################################################
+# keylime TPM 2.0 Dockerfile
+#
+# This file is for automatic test running of Keylime and rust-keylime.
+# It is not recommended for use beyond testing scenarios.
+##############################################################################
+
+FROM quay.io/fedora/fedora
+
+# environment variables
+ARG BRANCH=master
+ENV container docker
+ENV HOME /root
+ENV KEYLIME_HOME ${HOME}/keylime
+ENV TPM_HOME ${HOME}/swtpm2
+COPY dbus-policy.conf /etc/dbus-1/system.d/
+
+# Packaged dependencies
+ENV PKGS_DEPS "automake \
+clang clang-devel \
+createrepo_c \
+czmq-devel \
+dbus \
+dbus-daemon \
+dbus-devel \
+dnf-plugins-core \
+efivar-devel \
+gcc \
+git \
+glib2-devel \
+glib2-static \
+gnulib \
+iproute \
+kmod \
+libarchive-devel \
+libselinux-python3 \
+libtool \
+libtpms \
+llvm llvm-devel \
+make \
+openssl-devel \
+pkg-config \
+procps \
+python3-cryptography \
+python3-dbus \
+python3-devel \
+python3-gpg \
+python3-pip \
+python3-requests \
+python3-setuptools \
+python3-sqlalchemy \
+python3-tornado \
+python3-virtualenv \
+python3-yaml \
+python3-zmq \
+redhat-rpm-config \
+rpm-build \
+rpm-sign \
+rust clippy cargo \
+swtpm \
+swtpm-tools \
+tpm2-abrmd \
+tpm2-tools \
+tpm2-tss \
+tpm2-tss-devel \
+uthash-devel \
+wget \
+which"
+
+ENV DEV_DEPS "strace openssl"
+
+RUN dnf makecache && \
+  dnf -y install $PKGS_DEPS $DEV_DEPS && \
+  dnf clean all && \
+  rm -rf /var/cache/dnf/*
+
+RUN git clone https://github.com/keylime/rust-keylime \
+  && cd rust-keylime \
+  && make all \
+  && make install \
+  && cd .. \
+  && rm -rf rust-keylime
+
+COPY start.sh /
+CMD ["/start.sh"]

--- a/security/keylime-poc/agent-with-swtpm/dbus-policy.conf
+++ b/security/keylime-poc/agent-with-swtpm/dbus-policy.conf
@@ -1,0 +1,12 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <policy context="default">
+    <!-- Allow everything to be sent -->
+    <allow send_destination="*" eavesdrop="true"/>
+    <!-- Allow everything to be received -->
+    <allow eavesdrop="true"/>
+    <!-- Allow anyone to own anything -->
+    <allow own="*"/>
+  </policy>
+</busconfig>

--- a/security/keylime-poc/agent-with-swtpm/start.sh
+++ b/security/keylime-poc/agent-with-swtpm/start.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -eux
+
+KEYLIME=/var/lib/keylime
+TPMDIR=/tmp/tpmdir
+
+# configure swtpm2 and start it
+mkdir -p "${TPMDIR}"
+chown tss:tss "${TPMDIR}"
+chmod 750 "${TPMDIR}"
+
+swtpm_setup --tpm2 \
+    --tpmstate "${TPMDIR}" \
+    --createek --decryption --create-ek-cert \
+    --create-platform-cert \
+    --display || true
+swtpm socket --tpm2 \
+    --tpmstate dir="${TPMDIR}" \
+    --flags startup-clear \
+    --ctrl type=tcp,port=2322 \
+    --server type=tcp,port=2321 \
+    --daemon
+sleep 2
+
+# configure dbus for abmrd
+sudo rm -rf /var/run/dbus
+sudo mkdir /var/run/dbus
+sudo dbus-daemon --system
+
+# run abmrd
+tpm2-abrmd \
+    --logger=stdout \
+    --tcti=swtpm: \
+    --allow-root \
+    --flush-all \
+    &
+sleep 2
+
+# prep image for running agent as non-root
+useradd -s /sbin/nologin -g tss keylime || true
+
+chown keylime:tss "${KEYLIME}" "${KEYLIME}"/secure
+chmod 770 "${KEYLIME}" "${KEYLIME}"/secure
+cp "${KEYLIME}"/cv_ca/cacert.crt "${KEYLIME}"/secure/
+chown keylime:tss "${KEYLIME}"/secure/cacert.crt
+
+# make swtpm CA accessible to tenant to validate EK cert
+# and verify it to be sure we have it right to avoid issues down the road
+cat /var/lib/swtpm-localca/{issuercert,swtpm-localca-rootca-cert}.pem > "${KEYLIME}"/tpm_cert_store/swtpm_localca.pem
+tpm2_getekcertificate > "${KEYLIME}"/ek.bin
+openssl x509 -inform DER -in "${KEYLIME}"/ek.bin -out "${KEYLIME}"/ek.pem
+openssl verify -CAfile "${KEYLIME}"/tpm_cert_store/swtpm_localca.pem "${KEYLIME}"/ek.pem
+sleep 2
+
+# run agent
+keylime_agent

--- a/security/keylime-poc/compose/.gitignore
+++ b/security/keylime-poc/compose/.gitignore
@@ -1,0 +1,1 @@
+allowlist.txt

--- a/security/keylime-poc/compose/README.md
+++ b/security/keylime-poc/compose/README.md
@@ -1,0 +1,21 @@
+# Keylime in Docker Compose POC
+<!-- cSpell:ignore keylime -->
+
+Make a Proof of Concept of [Keylime in Docker Compose](compose/README.md).
+
+This will also work as part of [Keylime Agent in k8s](../k8s/README.md) POC,
+as Keylime Verifier, Registrar and Tenant will be outside k8s, but Agent inside.
+This creates interesting problems to be solved as Agent traffic will need to
+flow via Ingress/LoadBalancer and it cannot be reached via IP.
+
+## Steps
+
+1. docker compose installed
+1. Keylime images built locally via upstream
+   [build_locally.sh](https://github.com/keylime/keylime/blob/master/docker/release/build_locally.sh)
+   (we need unreleased fixes from `master`).
+1. `docker compose up --build` to launch it
+1. `./tenant.sh -c add` to verify stack works and agent gets added to verifier,
+   with EK certificate from software TPM.
+
+After this, feel free to play with `./tenant.sh`.

--- a/security/keylime-poc/compose/agent.conf
+++ b/security/keylime-poc/compose/agent.conf
@@ -1,0 +1,86 @@
+[agent]
+# The configuration file version
+version = "2.3"
+
+# The agent's UUID.
+uuid = "c47b9ea2-2bc2-461b-957b-e77dbcf35e5e"
+# uuid = "hash_ek"
+# uuid = "generate"
+
+# The keylime working directory. The default value is /var/lib/keylime
+keylime_dir = "/var/lib/keylime"
+
+# The size of the memory-backed tmpfs partition where Keylime stores crypto keys.
+# Use syntax that the 'mount' command would accept as a size parameter for tmpfs.
+# The default below sets it to 1 megabyte.
+secure_size = "1m"
+# run_as = "keylime:tss"
+
+# Enable mTLS communication between agent, verifier and tenant.
+# Details on why setting it to "false" is generally considered insecure can be found
+# on https://github.com/keylime/keylime/security/advisories/GHSA-2m39-75g9-ff5r
+agent_enable_mtls = "true"
+
+# The name of the file containing the Keylime agent TLS server private key.
+# This private key is used to serve the Keylime agent REST API
+# A new private key is generated in case it is not found.
+# If set as "default", the "server-private.pem" value is used.
+# If a relative path is set, it will be considered relative from the keylime_dir.
+# If an absolute path is set, it is used without change
+server_key = "secure/agent.key"
+
+# The name of the file containing the X509 certificate used as the Keylime agent
+# server TLS certificate.
+# This certificate must be self signed.
+# If set as "default", the "server-cert.crt" value is used
+# If a relative path is set, it will be considered relative from the keylime_dir.
+# If an absolute path is set, it is used without change.
+server_cert = "secure/agent.crt"
+
+# The CA that signs the client certificates of the tenant and verifier.
+# If set as "default" the "cv_ca/cacert.crt" value, relative from the
+# keylime_dir is used.
+# If a relative path is set, it will be considered relative from the keylime_dir.
+# If an absolute path is set, it is used without change.
+trusted_client_ca = "secure/cacert.crt"
+
+# The address and port of registrar server which agent communicate with
+registrar_ip = "127.0.0.2"
+registrar_port = 8890
+
+# The binding IP address and port for the agent server
+ip = "0.0.0.0"
+port = 9002
+
+# Address and port where the verifier and tenant can connect to reach the agent.
+# These keys are optional.
+contact_ip = "127.0.0.3"
+contact_port = 9002
+
+# Use this option to state the existing TPM ownerpassword.
+# This option should be set only when a password is set for the Endorsement
+# Hierarchy (e.g. via "tpm2_changeauth -c e").
+# In order to use a hex value for the password, use the prefix "hex:"
+# For example if tpm2_changeauth -c e "hex:00a1b2c3e4" has run, the config option
+# would be 'tpm_ownerpassword = "hex:00a1b2c3e4"'
+# If no password was set, keep the empty string "".
+tpm_ownerpassword = ""
+tpm_version = "2"
+
+# enc_keyname = "derived_tci_key"
+# dec_payload_file = "decrypted_payload"
+# extract_payload_zip = true
+# enable_revocation_notifications = false
+# revocation_actions_dir = "/usr/libexec/keylime"
+# revocation_cert = "default"
+# revocation_actions = ""
+# payload_script = "autorun.sh"
+# allow_payload_revocation_actions = true
+# tpm_hash_alg = "sha256"
+# tpm_encryption_alg = "rsa"
+# tpm_signing_alg = "rsassa"
+# ek_handle = "generate"
+# enable_iak_idevid = false
+# agent_data_path = ""
+# ima_ml_path = "default"
+# measuredboot_ml_path = "default"

--- a/security/keylime-poc/compose/compose.yml
+++ b/security/keylime-poc/compose/compose.yml
@@ -1,0 +1,72 @@
+# need locally built keylime tenant,registrar,verifier images
+# see: https://github.com/keylime/keylime/blob/master/docker/release/build_locally.sh
+# agent image is built from custom Dockerfile in ../agent-with-swtpm
+
+services:
+  keylime-verifier:
+    image: keylime_verifier:latest  # locally built
+    hostname: keylime-verifier
+    volumes:
+      - ./verifier.conf:/etc/keylime/verifier.conf:ro
+      - ./logging.conf:/etc/keylime/logging.conf:ro
+      - secure_volume:/var/lib/keylime
+    ports:
+      - "8881:8881"
+    user: root
+
+  keylime-registrar:
+    image: keylime_registrar:latest  # locally built
+    hostname: keylime-registrar
+    depends_on:
+      - keylime-verifier
+    volumes:
+      - ./registrar.conf:/etc/keylime/registrar.conf:ro
+      - ./logging.conf:/etc/keylime/logging.conf:ro
+      - secure_volume:/var/lib/keylime
+    ports:
+      - "8891:8891"
+      - "8890:8890"
+    user: root
+    entrypoint: ["bash", "-c", "sleep 5; keylime_registrar"]
+
+  keylime-tenant:
+    image: keylime_tenant:latest  # locally built
+    hostname: keylime-tenant
+    network_mode: host
+    depends_on:
+      - keylime-verifier
+      - keylime-registrar
+    volumes:
+      - ./tenant.conf:/etc/keylime/tenant.conf:ro
+      - ./logging.conf:/etc/keylime/logging.conf:ro
+      - secure_volume:/var/lib/keylime
+    user: root
+    entrypoint: ["bash", "-c", "tail -f /dev/null"]
+
+  keylime-agent:
+    build:
+      # image: quay.io/keylime/keylime_agent:master + swtpm config
+      context: ../agent-with-swtpm
+      dockerfile: ../agent-with-swtpm/Dockerfile
+    hostname: keylime-agent
+    network_mode: host
+    user: root
+    depends_on:
+      - keylime-verifier
+      - keylime-registrar
+    environment:
+      - TPM2TOOLS_TCTI=tabrmd:bus_type=system
+      - TCTI=tabrmd:bus_type=system
+      - RUST_LOG=keylime_agent=debug
+    volumes:
+      - /sys/kernel/security:/sys/kernel/security:ro
+      - ./agent.conf:/etc/keylime/agent.conf:ro
+      - secure_volume:/var/lib/keylime
+      - agent_volume:/var/lib/keylime/secure
+
+volumes:
+  secure_volume:
+  agent_volume:
+    driver_opts:
+      type: tmpfs
+      device: tmpfs

--- a/security/keylime-poc/compose/logging.conf
+++ b/security/keylime-poc/compose/logging.conf
@@ -1,0 +1,32 @@
+# Keylime logging configuration
+
+[logging]
+version = 2.3
+
+[loggers]
+keys = root,keylime
+
+[handlers]
+keys = consoleHandler
+
+[formatters]
+keys = formatter
+
+[formatter_formatter]
+format = %(asctime)s.%(msecs)03d - %(name)s - %(levelname)s - %(message)s
+datefmt = %Y-%m-%d %H:%M:%S
+
+[logger_root]
+level = DEBUG
+handlers = consoleHandler
+
+[handler_consoleHandler]
+class = StreamHandler
+level = DEBUG
+formatter = formatter
+args = (sys.stdout,)
+
+[logger_keylime]
+level = DEBUG
+qualname = keylime
+handlers =

--- a/security/keylime-poc/compose/registrar.conf
+++ b/security/keylime-poc/compose/registrar.conf
@@ -1,0 +1,120 @@
+[jenkins@bm08b-jenkins keylime_config]$ cat registrar.conf
+# Keylime registrar configuration
+[registrar]
+
+# The configuration file version number
+version = 2.3
+
+# The binding address and port for the registrar server
+ip = "0.0.0.0"
+port = 8890
+tls_port = 8891
+
+# The 'tls_dir' option define the directory where the keys and certificates are
+# stored.
+#
+# If set as 'generate', automatically generate a CA, keys, and certificates for
+# the registrar server in the /var/lib/keylime/reg_ca directory, if not present.
+#
+# The 'server_key', 'server_cert', and 'trusted_client_ca' options should all be
+# set with the 'default' keyword when 'generate' keyword is set for 'tls_dir'.
+#
+# If set as 'default', share the files with the verifier by using the
+# 'var/lib/keylime/cv_ca' directory, which should contain the files indicated by
+# the 'server_key', 'server_cert', and 'trusted_client_ca' options.
+tls_dir = default
+
+# The name of the file containing the Keylime registrar server private key.
+# The file should be stored in the directory set in the 'tls_dir' option.
+# This private key is used to serve the Keylime registrar REST API
+#
+# If set as 'default', the 'server-private.pem' value is used.
+server_key = default
+
+# Set the password used to decrypt the private key file.
+# If 'tls_dir = generate', this password will also be used to protect the
+# generated server private key.
+# If left empty, the private key will not be encrypted.
+server_key_password =
+
+# The name of the file containing the Keylime registrar server certificate.
+# The file should be stored in the directory set in the 'tls_dir' option.
+#
+# If set as 'default', the 'server-cert.crt' value is used.
+server_cert = default
+
+# The list of trusted client CA certificates.
+# The files in the list should be stored in the directory set in the 'tls_dir'
+# option.
+#
+# If set as 'default', the value is set as '[cacert.crt]'
+trusted_client_ca = default
+
+# Database URL Configuration
+# See this document https://keylime.readthedocs.io/en/latest/installation.html#database-support
+# for instructions on using different database configurations.
+#
+# An example of database_url value for using sqlite:
+#   sqlite:////var/lib/keylime/reg_data.sqlite
+# An example of database_url value for using mysql:
+#   mysql+pymysql://keylime:keylime@keylime_db:[port]/registrar?charset=utf8
+#
+# If set as 'sqlite' keyword, will use the configuration set by the file located
+# at "/var/lib/keylime/reg_data.sqlite".
+database_url = sqlite
+
+# Limits for DB connection pool size in sqlalchemy
+# (https://docs.sqlalchemy.org/en/14/core/pooling.html#api-documentation-available-pool-implementations)
+database_pool_sz_ovfl = 5,10
+
+# Whether to automatically update the DB schema using alembic
+auto_migrate_db = True
+
+# Durable Attestation is currently marked as an experimental feature
+# In order to enable Durable Attestation, an "adapter" for a Persistent data Store
+# (time-series like database) needs to be specified. Some example adapters can be
+# found under "da/examples" so, for instance
+#      "durable_attestation_import = keylime.da.examples.redis.py"
+# could be used to interact with a Redis (Persistent data Store)
+durable_attestation_import =
+
+# If an adapter for Durable Attestation was specified, then the URL for a Persistent Store
+# needs to be specified here. A second optional URL could be specified, for a
+# Rekor Transparency Log. A third additional URL could be specified, pointing to a
+# Time Stamp Authority (TSA), compatible with RFC3161. Additionally, one might need to
+# specify a path containing certificates required by the stores or TSA. Continuing with
+# the above example, the following values could be assigned to the parameters:
+#      "persistent_store_url=redis://127.0.0.1:6379?db=10&password=/root/redis.auth&prefix=myda"
+#      "transparency_log_url=http://127.0.0.1:3000"
+#      "time_stamp_authority_url=http://127.0.0.1:2020"
+#      "time_stamp_authority_certs_path=~/mycerts/tsa_cert1.pem"
+persistent_store_url =
+transparency_log_url =
+time_stamp_authority_url =
+time_stamp_authority_certs_path =
+
+# If Durable Attestation was enabled, which requires a Persistent Store URL
+# to be specified, the two following parameters control the format and enconding
+# of the stored attestation artifacts (defaults "json" for format and "" for encoding)
+persistent_store_format = json
+persistent_store_encoding =
+
+# If Durable Attestation was enabled with a Transparency Log URL was specified,
+# the digest algorithm for signatures is controlled by this parameter (default "sha256")
+transparency_log_sign_algo = sha256
+
+# If Durable Attestation was enabled with a Transparency Log URL was specified,
+# a keylime administrator can specify some agent attributes (including attestation
+# artifacts, such as quotes and logs) to be signed by the registrar. The use of "all"
+# will result in the whole "package" (agent + artifacts) being signed and leaving it empty
+# will mean no signing should be done.
+signed_attributes = ek_tpm,aik_tpm,ekcert
+
+# What TPM-based identity is allowed to be used to register agents.
+# The options "default" and "iak_idevid" will only allow registration with IAK and IDevID if python cryptography is version 38.0.0 or higher.
+# The following options are accepted:
+# "default": either an EK or IAK and IDevID may be used. In the case that cryptography version is <38.0.0 only EK will be used
+# "ek_cert_or_iak_idevid": this is equivalent to default
+# "ek_cert": only allow agents to use an EK to register
+# "iak_idevid": only allow agents with an IAK and IDevID to register
+tpm_identity = default

--- a/security/keylime-poc/compose/tenant.conf
+++ b/security/keylime-poc/compose/tenant.conf
@@ -1,0 +1,130 @@
+# Keylime tenant configuration
+[tenant]
+
+# The configuration file version number
+version = 2.3
+
+# The verifier IP address and port
+verifier_ip = 127.0.0.1
+verifier_port = 8881
+
+# The registrar IP address and port
+registrar_ip = 127.0.0.2
+registrar_port = 8891
+
+# The 'tls_dir' option define the directory where the keys and certificates are
+# stored.
+#
+# If set as 'default', share the files with the verifier by using the
+# 'var/lib/keylime/cv_ca', which should contain the files indicated by the
+# 'client_key', 'client_cert', and 'trusted_server_ca' options.
+tls_dir = default
+
+# Enable mTLS communication between agent, verifier and tenant.
+# Details on why setting it to "False" is generally considered insecure can be found
+# on https://github.com/keylime/keylime/security/advisories/GHSA-2m39-75g9-ff5r
+enable_agent_mtls = True
+
+# The name of the file containing the Keylime tenant client private key.
+# The file should be stored in the directory set in the 'tls_dir' option.
+# This private key is used by the Keylime tenant to connect to the other
+# services using TLS.
+#
+# If set as 'default', the 'client-private.pem' value is used.
+client_key = default
+
+# Set the password used to encrypt the private key file.
+# If client_key is set as 'default', should match the password set in the
+# 'client_key_password' option in the verifier configuration file
+client_key_password =
+
+# The name of the file containing the Keylime tenant client certificate.
+# The file should be stored in the directory set in the 'tls_dir' option.
+# This certificate is used by the Keylime tenant to connect to the other
+# services using TLS.
+#
+# If set as 'default', the 'client-cert.crt' value is used.
+client_cert = default
+
+# The list of trusted server CA certificates.
+# The files in the list should be stored in the directory set in the 'tls_dir'
+# option.
+#
+# If set as 'default', the value is set as '[cacert.crt]'
+trusted_server_ca = default
+
+# Directory containing the EK CA certificates.
+# The EK certificate provided by the agent will be validated against the CAs
+# located in this directory.
+tpm_cert_store = /var/lib/keylime/tpm_cert_store
+
+# Maximum size of the payload in bytes. The value should match the 'secure_size'
+# option in the agent configuration
+max_payload_size = 1048576
+
+# List of hash algorithms used for PCRs
+# Accepted values: sha512, sha384, sha256, sha1
+accept_tpm_hash_algs = ['sha512', 'sha384', 'sha256']
+
+# List of encryption algorithms to use with the TPM
+# Accepted values: ecc, rsa
+accept_tpm_encryption_algs = ['ecc', 'rsa']
+
+# List of signature algorithms to use
+# Accepted values: rsassa, rsapss, ecdsa, ecdaa, ecschnorr
+accept_tpm_signing_algs = ['ecschnorr', 'rsassa']
+
+# Wether or not to use an exponantial backoff algorithm for retries.
+exponential_backoff = True
+
+# Either how long to wait between failed attempts to communicate with the TPM
+# in seconds, or the base for the exponential backoff algorithm if enabled via
+# "exponential_backoff" option.
+# Floating point values are accepted.
+retry_interval = 2
+
+# Integer number of retries to communicate with the TPM before giving up.
+max_retries = 5
+
+# Request timeout in seconds.
+request_timeout = 60
+
+# Tell the tenant whether to require an EK certificate from the TPM.
+# If set to False the tenant will ignore EK certificates entirely.
+#
+# WARNING: SETTING THIS OPTION TO FALSE IS VERY DANGEROUS!!!
+#
+# If you disable this check, then you may not be talking to a real TPM.
+# All the security guarantees of Keylime rely upon the security of the EK
+# and the assumption that you are talking to a spec-compliant and honest TPM.
+
+# Some physical TPMs do not have EK certificates, so you may need to set
+# this to "False" for some deployments.  If you do set it to "False", you
+# MUST use the 'ek_check_script' option below to specify a script that will
+# check the provided EK against a allowlist for the environment that has
+# been collected in a trustworthy way.  For example, the cloud provider
+# might provide a signed list of EK public key hashes.  Then you could write
+# an ek_check_script that checks the signature of the allowlist and then
+# compares the hash of the given EK with the allowlist.
+require_ek_cert = True
+
+# Optional script to execute to check the EK and/or EK certificate against a
+# allowlist or any other additional EK processing you want to do. Runs in
+# /var/lib/keylime. You call also specify an absolute path to the script.
+# Script should return 0 if the EK or EK certificate are valid.  Any other
+# return value will invalidate the tenant quote check and prevent
+# bootstrapping a key.
+#
+# The various keys are passed to the script via environment variables:
+# EK - contains a PEM encoded version of the public EK
+# EK_CERT - contains a DER encoded EK certificate if one is available.
+# PROVKEYS - contains a json document containing EK, EKcert, and AIK from the
+# provider.  EK and AIK are in PEM format.  The EKcert is in base64 encoded
+# DER format.
+#
+# Set to blank to disable this check.  See warning above if require_ek_cert
+# is "False".
+ek_check_script =
+
+# Path to file containing the measured boot reference state
+mb_refstate =

--- a/security/keylime-poc/compose/tenant.sh
+++ b/security/keylime-poc/compose/tenant.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Run docker-compose up -d first to have infra in place
+
+set -eu
+
+# test with args "-c add" as that triggers basically the whole keylime/tpm chain
+docker exec \
+    -it \
+    --user root \
+    compose-keylime-tenant-1 \
+    keylime_tenant \
+    --uuid c47b9ea2-2bc2-461b-957b-e77dbcf35e5e \
+    "$@"

--- a/security/keylime-poc/compose/verifier.conf
+++ b/security/keylime-poc/compose/verifier.conf
@@ -1,0 +1,252 @@
+# Keylime verifier configuration
+[verifier]
+
+# The configuration file version number
+version = 2.3
+
+# Unique identifier for the each verifier instances.
+uuid = default
+
+# The binding address and port for the verifier server
+ip = "0.0.0.0"
+port = 8881
+
+# The address and port of registrar server that the verifier communicates with
+registrar_ip = "127.0.0.2"
+registrar_port = 8891
+
+# Enable mTLS communication between agent, verifier and tenant.
+# Details on why setting it to "False" is generally considered insecure can be found
+# on https://github.com/keylime/keylime/security/advisories/GHSA-2m39-75g9-ff5r
+enable_agent_mtls = True
+
+# The 'tls_dir' option define the directory where the keys and certificates are
+# stored.
+#
+# If set as 'generate', automatically generate a CA, keys, and certificates for
+# the client and the server in the /var/lib/keylime/cv_ca directory, if not
+# present.
+#
+# The 'server_key', 'server_cert', 'client_key', 'client_cert',
+# 'trusted_client_ca', and 'trusted_server_ca' options should all be set with
+# the 'default' keyword when 'generate' keyword is set for 'tls_dir'.
+#
+# If set as 'default', the 'var/lib/keylime/cv_ca' directory is used, which
+# should contain the files indicated by  the 'server_key', 'server_cert',
+# 'client_key', 'client_cert', 'trusted_client_ca', and 'trusted_server_ca'
+# options.
+tls_dir = generate
+
+# The name of the file containing the Keylime verifier server private key.
+# The file should be stored in the directory set in the 'tls_dir' option.
+# This private key is used to serve the Keylime verifier REST API
+#
+# If set as 'default', the 'server-private.pem' value is used.
+server_key = default
+
+# Set the password used to decrypt the server private key file.
+# If 'tls_dir = generate', this password will also be used to protect the
+# generated server private key.
+# If left empty, the private key will not be encrypted.
+server_key_password =
+
+# The name of the file containing the Keylime verifier server certificate.
+# The file should be stored in the directory set in the 'tls_dir' option.
+#
+# If set as 'default', the 'server-cert.crt' value is used.
+server_cert = default
+
+# The list of trusted client CA certificates.
+# The files in the list should be stored in the directory set in the 'tls_dir'
+# option.
+#
+# If set as 'default', the value is set as '[cacert.crt]'
+trusted_client_ca = default
+
+# The name of the file containing the Keylime verifier client private key.
+# The file should be stored in the directory set in the 'tls_dir' option.
+# This private key is used by the Keylime verifier to connect to the other
+# services using TLS.
+#
+# If set as 'default', the 'client-private.pem' value is used.
+client_key = default
+
+# Set the password used to decrypt the client private key file.
+# If 'tls_dir = generate', this password will also be used to protect the
+# generated client private key.
+# If left empty, the private key will not be encrypted.
+client_key_password =
+
+# The name of the file containing the Keylime verifier client certificate.
+# The file should be stored in the directory set in the 'tls_dir' option.
+# This certificate is used by the Keylime verifier to connect to the other
+# services using TLS.
+#
+# If set as 'default', the 'client-cert.crt' value is used.
+client_cert = default
+
+# The list of trusted server CA certificates.
+# The files in the list should be stored in the directory set in the 'tls_dir'
+# option.
+#
+# If set as 'default', the value is set as '[cacert.crt]'
+trusted_server_ca = default
+
+# Database URL Configuration
+# See this document https://keylime.readthedocs.io/en/latest/installation.html#database-support
+# for instructions on using different database configurations.
+#
+# An example of database_url value for using sqlite:
+#   sqlite:////var/lib/keylime/cv_data.sqlite
+# An example of database_url value for using mysql:
+#   mysql+pymysql://keylime:keylime@keylime_db:[port]/verifier?charset=utf8
+#
+# If set as 'sqlite' keyword, will use the configuration set by the file located
+# at "/var/lib/keylime/cv_data.sqlite".
+database_url = sqlite
+
+# Limits for DB connection pool size in sqlalchemy
+# (https://docs.sqlalchemy.org/en/14/core/pooling.html#api-documentation-available-pool-implementations)
+database_pool_sz_ovfl = 5,10
+
+# Whether to automatically update the DB schema using alembic
+auto_migrate_db = True
+
+# The number of worker processes to use for the cloud verifier.
+# Set to "0" to create one worker per processor.
+num_workers = 2
+
+# Wether or not to use an exponantial backoff algorithm for retries.
+exponential_backoff = True
+
+# Either how long to wait between failed attempts to connect to a cloud agent
+# in seconds, or the base for the exponential backoff algorithm.
+# Floating point values accepted here.
+retry_interval = 2
+
+# Number of retries to connect to an agent before giving up. Must be an integer.
+max_retries = 5
+
+# Time between integrity measurement checks, in seconds.  If set to "0", checks
+# will done as fast as possible.  Floating point values accepted here.
+quote_interval = 2
+
+# The verifier limits the size of upload payloads (allowlists) which defaults to
+# 100MB (104857600 bytes). This setting can be raised (or lowered) based on the
+# size of the actual payloads
+max_upload_size = 104857600
+
+# Timeout in seconds for requests made to agents
+request_timeout = 60.0
+
+# The name of the boot attestation policy to use in comparing a measured boot event log
+# with a measured boot reference state.
+# A policy is a Python object that `isinstance` of `keylime.elchecking.policies.Policy`
+# and was registered by calling `keylime.elchecking.policies.register`.
+# The keylime agent extracts the measured boot event log.
+# The verifier client specifies the measured boot reference state to use;
+# this is specified independently for each agent.
+# Depending on the policy, the same reference state may be usable with multiple agents.
+# The `accept-all` policy ignores the reference state and approves every log.
+measured_boot_policy_name = accept-all
+
+# This is a list of Python modules to dynamically load, for example to register
+# additional boot attestation policies.
+# Empty strings in the list are ignored.
+# A module here may be relative, in which case it is interpreted
+# relative to the keylime.elchecking package.
+# The default value for this config item is the empty list.
+measured_boot_imports = []
+
+# This is used to manage the number of times measure boot attestation
+# is done. In other words, it controls the number of times the call
+# to the measure boot policy engine is made to evaluate the boot log
+# against the policy specified.
+# Here are its possible values and number of bootlog evaluations.
+# once (default)  : Bootlog evaluation will be done for only one time.
+# always          : Bootlog evaluation will always be done (i.e. for unlimited times).
+measured_boot_evaluate = once
+
+# Severity labels for revocation events strictly ordered from least severity to
+# highest severtiy.
+severity_labels = ["info", "notice", "warning", "error", "critical", "alert", "emergency"]
+
+# Severity policy that matches different event_ids to the severity label.
+# The rules are evaluated from the beginning of the list and the first match is
+# used. The event_id can also be a regex. Default policy assigns the highest
+# severity to all events.
+severity_policy = [{"event_id": ".*", "severity_label" : "emergency"}]
+
+# If files are already opened when IMA tries to measure them this causes
+# a time of measure, time of use (ToMToU) error entry.
+# By default we ignore those entries and only print a warning.
+# Set to False to treat ToMToU entries as errors.
+ignore_tomtou_errors = False
+
+# Durable Attestation is currently marked as an experimental feature
+# In order to enable Durable Attestation, an "adapter" for a Persistent data Store
+# (time-series like database) needs to be specified. Some example adapters can be
+# found under "da/examples" so, for instance
+#      "durable_attestation_import = keylime.da.examples.redis.py"
+# could be used to interact with a Redis (Persistent data Store)
+durable_attestation_import =
+
+# If an adapter for Durable Attestation was specified, then the URL for a Persistent Store
+# needs to be specified here. A second optional URL could be specified, for a
+# Rekor Transparency Log. A third additional URL could be specified, pointing to a
+# Time Stamp Authority (TSA), compatible with RFC3161. Additionally, one might need to
+# specify a path containing certificates required by the stores or TSA. Continuing with
+# the above example, the following values could be assigned to the parameters:
+#      "persistent_store_url=redis://127.0.0.1:6379?db=10&password=/root/redis.auth&prefix=myda"
+#      "transparency_log_url=http://127.0.0.1:3000"
+#      "time_stamp_authority_url=http://127.0.0.1:2020"
+#      "time_stamp_authority_certs_path=~/mycerts/tsa_cert1.pem"
+persistent_store_url =
+transparency_log_url =
+time_stamp_authority_url =
+time_stamp_authority_certs_path =
+
+# If Durable Attestation was enabled, which requires a Persistent Store URL
+# to be specified, the two following parameters control the format and enconding
+# of the stored attestation artifacts (defaults "json" for format and "" for encoding)
+persistent_store_format = json
+persistent_store_encoding =
+
+# If Durable Attestation was enabled with a Transparency Log URL was specified,
+# the digest algorithm for signatures is controlled by this parameter (default "sha256")
+transparency_log_sign_algo = sha256
+
+# If Durable Attestation was enabled with a Transparency Log URL was specified,
+# a keylime administrator can specify some agent attributes (including attestation
+# artifacts, such as quotes and logs) to be signed by the verifier. The use of "all"
+# will result in the whole "package" (agent + artifacts) being signed and leaving it empty
+# will mean no signing should be done.
+signed_attributes =
+
+# Require that allowlists are signed with a key passed via the tenant tool
+require_allow_list_signatures = False
+
+[revocations]
+
+# List of revocation notification methods to enable.
+#
+# Available methods are:
+#
+# "agent": Deliver notification directly to the agent via the REST
+# protocol.
+#
+# "zeromq": Enable the ZeroMQ based revocation notification method;
+# zmq_ip and zmq_port options must be set. Currently this only works if you are
+# using keylime-CA.
+#
+# "webhook": Send notification via webhook. The endpoint URL must be
+# configured with 'webhook_url' option. This can be used to notify other
+# systems that do not have a Keylime agent running.
+enabled_revocation_notifications = ['agent']
+
+# The binding address and port of the revocation notifier service via ZeroMQ.
+zmq_ip = 127.0.0.1
+zmq_port = 8992
+
+# Webhook url for revocation notifications.
+webhook_url =


### PR DESCRIPTION
Make a Proof of Concept of Keylime is k8s cluster.
    
This part 1 is adding Keylime in Docker Compose. This doubles as the keylime service part in part 2, where agent(s) move to k8s. Agent image is having SWTPM module built-in, so this environment is portable across machines, regardless of their TPM chip or lack there of.

This POC is needed as the concept of having Keylime Tenant/Verifier/Registrar outside k8s cluster, but Keylime Agent in k8s cluster and being accessed via Ingress/LoadBalancer IP, is something Keylime maintainers did not think originally as a use-case. This has several issues with the current design, and while there is a proposal/ study for changing from "pull model" to "push model", it is miles away and this POC tries to find out the minimal changes needed to make the current model work for this use case.