### PR TITLE
add cosign as option to container-signing-poc

### DIFF
--- a/security/container-signing-poc/Makefile
+++ b/security/container-signing-poc/Makefile
@@ -1,13 +1,16 @@
 # top level makefile to run e2e test
-# notation -> oras copy -> kyverno
+# 1st flow: notation -> oras copy -> kyverno
+# 2nd flow: cosign -> kyverno
+# kyverno tests both cosign and notation
 
 NOTATION_DIR := notation
 ORAS_DIR := oras
 KYVERNO_DIR := kyverno
+COSIGN_DIR := cosign
 
 SHELL := /bin/bash
 
-.PHONY: all e2e clean
+.PHONY: all e2e clean notation-e2e cosign-e2e
 
 all:
 	@echo "targets: e2e clean"
@@ -15,10 +18,23 @@ all:
 e2e:
 	make -C $(NOTATION_DIR) e2e
 	make -C $(ORAS_DIR) e2e
+	make -C $(COSIGN_DIR) e2e
 	make -C $(KYVERNO_DIR) e2e
 	@echo "e2e test done!"
+
+notation-e2e:
+	make -C $(NOTATION_DIR) e2e
+	make -C $(ORAS_DIR) e2e
+	make -C $(KYVERNO_DIR) notation-e2e
+	@echo "notation e2e test done!"
+
+cosign-e2e:
+	make -C $(COSIGN_DIR) e2e
+	make -C $(KYVERNO_DIR) cosign-e2e
+	@echo "cosign e2e test done!"
 
 clean:
 	make -C $(NOTATION_DIR) clean-e2e
 	make -C $(ORAS_DIR) clean-e2e
+	make -C $(COSIGN_DIR) clean-e2e
 	make -C $(KYVERNO_DIR) clean-e2e

--- a/security/container-signing-poc/README.md
+++ b/security/container-signing-poc/README.md
@@ -1,24 +1,30 @@
 # Container Signing POC
+<!-- cSpell:ignore kyverno,oras,sigstore,rebranded,pkcs,fulcio,rekor -->
 
 This experiment is three-fold:
 
-1. [Signing images with Notation, especially with custom signers](notation/README.md)
-1. [Moving signatures from one registry to another](oras/README.md)
-1. [Validating the signing with Kyverno, in a Kind cluster](kyverno/README.md)
+- [Signing images with Notation, especially with custom signers](notation/README.md)
+- [Moving signatures from one registry to another](oras/README.md)
+or
+- [Signing with Cosign](cosign/README.md)
+then
+- [Validating the signing with Kyverno, in a Kind cluster](kyverno/README.md)
 
 ```mermaid
 flowchart LR
    notation(Container signing with Notation)
    oras(Signature relocation with Oras)
    kyverno(Signature validation with Kyverno)
+   cosign(Container signing and relocation with Cosign)
 
    notation-->oras
    oras-->kyverno
+   cosign->kyverno
 ```
 
 ## TL;DR of the POC
 
-Basically, the POC is finding the following:
+Basically, the POC is finding the following related to Notation:
 
 1. Notation is extendable with their plugin system
 1. Plugin that can call any external script or binary to produce a signature has
@@ -26,9 +32,22 @@ Basically, the POC is finding the following:
 1. This allows any in-house, custom integration to private signer, regardless
    of the interface, even manual/email works (despite being brittle), without
    writing a full-fledged plugin with Go.
+1. Notation can handle SHA512 with PSS, no problem
 1. Kyverno can easily be configured to verify Notation signatures runtime, via
    their admission controller and pluggable policies.
 1. Oras can be used to move containers and signatures from CI to production
+
+And related to Cosign:
+
+1. Cosign does not need plugins as it can be operated via command line to
+   achieve external signing.
+1. Cosign can also save and load images with signatures by itself, Oras is not
+   needed
+1. Cosign ecosystem can only handle RSA256 with PKCS#1. Anything other than
+   those lack support as Sigstore wants support to be homogenous across all of
+   its services, so implementing it is not trivial.
+1. Kyverno can be used with Cosign the same as Notation, just a little bit more
+   configuration needed in the manifest to disable transparency logs and SCTs.
 
 ## e2e test
 
@@ -44,6 +63,8 @@ This does the following:
 
 End-to-end test will use the same certificates and same signature through the
 whole chain for verify end-to-end functionality.
+
+Same happens with Cosign, with registry on port `5003`.
 
 ## Notes
 
@@ -72,3 +93,19 @@ is in beta.
 Kyverno can also verify Sigstore Cosign signatures.
 
 Kyverno is generic policy engine, capable of replacing OPA Gatekeeper etc.
+
+### Notes on Oras
+
+Oras can handle any OCI binary or blob perfectly fine. With Cosign, using Oras
+is not necessary as cosign CLI can load/save OCI containers identically to
+Oras, which includes handling Cosign signatures attached to images.
+
+### Notes on Cosign
+
+While other components here are CNCF projects, Cosign is OpenSSF project. It is
+developed on top of TUF framework, and is more of a continuation to Notary v1
+than Notary v2/Notation ever was. Sigstore ecosystem contains not only Cosign,
+but also Rekor and Fulcio for certificate management and transparency log servers,
+as well as support for many languages, like Go, Python, Ruby, Java etc. This is
+a strength and a weakness the same time, as mentioned before related to SHA256
+hardcoding problem.

--- a/security/container-signing-poc/cosign/.gitignore
+++ b/security/container-signing-poc/cosign/.gitignore
@@ -1,0 +1,1 @@
+examples/*

--- a/security/container-signing-poc/cosign/Makefile
+++ b/security/container-signing-poc/cosign/Makefile
@@ -1,0 +1,82 @@
+# cosign signing test
+
+TEST_REGISTRY := 127.0.0.1:5003
+TEST_REGISTRY_NAME := cosign-registry
+TEST_REGISTRY_IMAGE := registry:2
+TEST_IMAGE := alpine
+TEST_IMAGE_TAG := 3.20.3
+TEST_DIGEST := sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d
+TEST_IMAGE_LOCAL := $(TEST_REGISTRY)/$(TEST_IMAGE):$(TEST_IMAGE_TAG)
+TEST_DIGEST_LOCAL := sha256:33735bd63cf84d7e388d9f6d297d348c523c044410f553bd878c6d7829612735
+TEST_IMAGE_SIGN := $(TEST_REGISTRY)/$(TEST_IMAGE)@$(TEST_DIGEST_LOCAL)
+EXAMPLES_DIR := examples
+
+SHELL := /bin/bash
+
+.PHONY: all clean registry test sign verify e2e clean-e2e check-tools save load
+
+all: check-tools
+	@echo "targets: test verify clean e2e clean-e2e"
+
+check-tools:
+	@type -a docker &>/dev/null || echo "error: Install docker: https://docs.docker.com/engine/install/"
+	@type -a cosign &>/dev/null || echo "error: Install cosign: https://docs.sigstore.dev/cosign/system_config/installation/"
+	@type -a openssl &>/dev/null || echo "error: openssl missing"
+
+clean:
+	rm -rf $(EXAMPLES_DIR)/$(TEST_IMAGE)-image
+	rm -f $(EXAMPLES_DIR)/*
+	docker rm -f $(TEST_REGISTRY_NAME) 2>/dev/null
+
+clean-e2e: clean
+
+registry:
+	docker run -d -p $(TEST_REGISTRY):5000 --name $(TEST_REGISTRY_NAME) $(TEST_REGISTRY_IMAGE)
+	docker pull $(TEST_IMAGE):$(TEST_IMAGE_TAG)@$(TEST_DIGEST)
+	docker tag $(TEST_IMAGE)@$(TEST_DIGEST) $(TEST_IMAGE_LOCAL)
+	docker push $(TEST_IMAGE_LOCAL)
+
+certificates:
+	./scripts/gencrt.sh
+
+test: check-tools registry certificates sign verify
+e2e: test save load
+
+sign:
+	cosign generate "$(TEST_IMAGE_SIGN)" > $(EXAMPLES_DIR)/payload.json
+	openssl dgst -sha256 -sign $(EXAMPLES_DIR)/leaf.key \
+		-out $(EXAMPLES_DIR)/payload.sig $(EXAMPLES_DIR)/payload.json
+	base64 $(EXAMPLES_DIR)/payload.sig > $(EXAMPLES_DIR)/payloadbase64.sig
+	cosign attach signature \
+		--payload $(EXAMPLES_DIR)/payload.json \
+		--signature $(EXAMPLES_DIR)/payloadbase64.sig \
+		$(TEST_IMAGE_SIGN)
+
+inspect:
+	cosign tree $(TEST_IMAGE_SIGN)
+
+verify: inspect
+	cosign verify \
+		--cert $(EXAMPLES_DIR)/leaf.crt \
+		--cert-chain $(EXAMPLES_DIR)/certificate_chain.pem \
+		--certificate-identity-regexp '.*' \
+		--certificate-oidc-issuer-regexp '.*' \
+		--private-infrastructure \
+		--insecure-ignore-sct \
+		$(TEST_IMAGE_SIGN)
+
+save:
+	cosign save \
+		--dir $(EXAMPLES_DIR)/$(TEST_IMAGE)-image \
+		--allow-insecure-registry=true \
+		$(TEST_IMAGE_SIGN)
+	tar cf $(EXAMPLES_DIR)/$(TEST_IMAGE).tar $(EXAMPLES_DIR)/$(TEST_IMAGE)-image
+	rm -rf $(EXAMPLES_DIR)/$(TEST_IMAGE)-image
+
+load:
+	tar xf $(EXAMPLES_DIR)/$(TEST_IMAGE).tar $(EXAMPLES_DIR)/$(TEST_IMAGE)-image
+	cosign load \
+		--allow-insecure-registry=true \
+		--dir $(EXAMPLES_DIR)/$(TEST_IMAGE)-image \
+		$(TEST_IMAGE_LOCAL)-loaded
+	cosign tree $(TEST_IMAGE_LOCAL)-loaded

--- a/security/container-signing-poc/cosign/README.md
+++ b/security/container-signing-poc/cosign/README.md
@@ -1,0 +1,156 @@
+<!-- cSpell:ignore oras,kyverno,airgap,rsassa,pkcs,sigstore -->
+
+# Cosign POC
+
+This POC aims to provide a Proof-of-Concept for using cosign to sign images
+using external signing service. It is complemented by the
+[Oras](../oras/README.md) and [Kyverno](../kyverno/README.md) parts to achieve
+full e2e POC.
+
+**References:**
+
+1. [Cosign container signature spec](https://github.com/sigstore/cosign/blob/main/specs/SIGNATURE_SPEC.md)
+is a must read.
+1. [Someone else doing the same](https://github.com/mvazquezc/mvazquezc.github.io/blob/85f301c3c3b8576a599e03470a3a76c600d6a586/content/posts/2024-04-25-signing-verifying-container-images-with-cosign/index.md)
+
+**TODO LIST**:
+
+- Change to external signer requested compatible signature
+   - Needs [cosign patch](https://github.com/sigstore/cosign/pull/3917) to work
+   - NOTE: cosign will not accept such trivial patch, see longer discussion
+      [here](#cosign-signing-algorithm-support)
+- Use Oras to move signature to prod registry
+   - "cosign save ..." can do what Oras does as well!
+- Verify the signature in K8s cluster, with Kyverno ClusterPolicy
+
+## Preparation
+
+NOTE: all this is done by `make test`, this is just explaining what it does.
+
+1. Verify basic tools exist
+
+   We need three tools installed and available in PATH:
+
+   - docker
+   - cosign
+   - openssl
+
+1. Run local registry where we can upload images and signatures
+
+   Commonly, `docker run -d --restart=always -p 127.0.0.1:5003:5000 registry:2`
+   does the trick.
+
+1. Push public alpine image to a local registry for testing
+
+   ```sh
+   docker pull alpine:3.20.3
+   docker tag alpine:3.20.3 127.0.0.1:5003/alpine:3.20.3
+   docker push 127.0.0.1:5003/alpine:3.20.3
+   ```
+
+1. Generate certificates for signing
+
+   ```sh
+   ./scripts/gencrt.sh
+   ```
+
+   Certificate config files to be simplified further.
+
+## Signing
+
+1. Generate payload for local image for signing
+
+   ```sh
+   cosign generate 127.0.0.1:5003/alpine:3.20.3 > output/payload.json
+   ```
+
+   The file `output/payload.json` is simple:
+
+   ```json
+   {
+      "critical": {
+         "identity": {
+            "docker-reference": "127.0.0.1:5003/alpine"
+         },
+         "image": {
+            "docker-manifest-digest": "sha256:33735bd63cf84d7e388d9f6d297d348c523c044410f553bd878c6d7829612735"
+         },
+         "type": "cosign container image signature"
+      },
+      "optional": null
+   }
+   ```
+
+1. Sign it and convert to base64
+
+   SHA512 with PSS padding is the wanted state. Note that it DOES NOT WORK
+   without cosign patch. IN PROGRESS.
+
+   ```sh
+   # Sign the payload with SHA256 - ONLY ONE THAT WORKS BY DEFAULT
+   openssl dgst -sha256 -sign keys/leaf.key \
+      -out output/payload.sig output/payload.json
+   base64 output/payload.sig > output/payloadbase64.sig
+   ```
+
+   The content of the file `output/payloadbase64.sig` looks like following:
+
+   ```console
+   MEUCIQDfcf0R+9nNACTQVxsXmlWXavKXWwCQuknLFbzknDRzkgIgVPLD7NUquGlJ+sQHQFziujKv
+   T1Zck4v6ZOG4LeLonKU=
+   ```
+
+   Signatures are binary, and thus base64 encoded.
+
+1. Upload signature to the registry
+
+   ```sh
+   cosign attach signature --payload output/payload.json \
+      --signature output/payloadbase64.sig 127.0.0.1:5000/alpine:3.20.3
+   ```
+
+## Verifying
+
+We need to verify with cosign. Note that SHA512/PSS do not work without patch.
+
+For flags, we need to ignore the identity/issuer with regex `.*`.
+We also need to ignore SCT. `--private-infrastructure` avoids transparency log
+queries, so no `--insecure-ignore-tlog` needed.
+
+```sh
+cosign verify \
+    --cert keys/leaf.crt \
+    --cert-chain keys/certificate_chain.pem \
+    --certificate-identity-regexp '.*' \
+    --certificate-oidc-issuer-regexp '.*' \
+    --private-infrastructure \
+    --insecure-ignore-sct \
+    "127.0.0.1:5003/alpine:3.20.3"
+```
+
+Which will succeed with some disclaimers:
+
+```console
+WARNING: Skipping tlog verification is an insecure practice that lacks of
+transparency and auditability verification for the signature.
+
+Verification for 127.0.0.1:5003/alpine:3.20.3 --
+The following checks were performed on each of these signatures:
+- The cosign claims were validated
+- The signatures were verified against the specified public key
+
+[{"critical":{"identity":{"docker-reference":"127.0.0.1:5003/alpine"},"image":{"docker-manifest-digest":"sha256:33735bd63cf84d7e388d9f6d297d348c523c044410f553bd878c6d7829612735"},"type":"cosign container image signature"},"optional":null}]
+```
+
+## Cosign signing algorithm support
+
+Sigstore/Cosign community does not what SHA512/PSS support unless it is covering
+their entire ecosystem. See [summary](https://github.com/sigstore/cosign/pull/3917#issuecomment-2451334036)
+in this issue.
+
+Some references:
+
+- [Issue from 2022 for allowing configurability](https://github.com/sigstore/cosign/issues/1775)
+- [Add --signing-algorithm flag PR](https://github.com/sigstore/cosign/pull/3497)
+- [Simple PSS/SHA512 support PR for verify](https://github.com/sigstore/cosign/pull/3917)
+- [Slack discussion about it](https://sigstore.slack.com/archives/C01PZKDL4DP/p1730288293793379)

--- a/security/container-signing-poc/cosign/scripts/gencrt.sh
+++ b/security/container-signing-poc/cosign/scripts/gencrt.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# create certificates in the examples dir
+
+# Create directories
+OUTPUT_DIR=examples
+mkdir -p "${OUTPUT_DIR}"
+
+# Generate Root CA key - we can use whatever, only signature algos matter
+# in our use-case
+# openssl genrsa -out "${OUTPUT_DIR}"/ca.key 4096
+openssl ecparam -name secp384r1 -genkey -noout -out "${OUTPUT_DIR}"/ca.key
+
+# Create Root CA config
+cat > "${OUTPUT_DIR}"/ca.conf << EOF
+[req]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_ca
+prompt = no
+
+[req_distinguished_name]
+CN = Root CA
+
+[v3_ca]
+basicConstraints = critical,CA:TRUE
+keyUsage = critical,keyCertSign,cRLSign,digitalSignature
+subjectKeyIdentifier = hash
+EOF
+
+# Generate Root CA certificate
+openssl req -new -x509 -days 365 -key "${OUTPUT_DIR}"/ca.key \
+    -config "${OUTPUT_DIR}"/ca.conf \
+    -out "${OUTPUT_DIR}"/ca.crt
+
+# Generate leaf key
+openssl genrsa -out "${OUTPUT_DIR}"/leaf.key 4096
+
+# Create leaf config
+cat > "${OUTPUT_DIR}"/leaf.conf << EOF
+[req]
+distinguished_name = req_distinguished_name
+prompt = no
+req_extensions = v3_req
+
+[req_distinguished_name]
+CN = signer@example.com
+
+[v3_req]
+basicConstraints = critical,CA:FALSE
+keyUsage = critical,digitalSignature
+extendedKeyUsage = critical,codeSigning,clientAuth
+subjectKeyIdentifier = hash
+subjectAltName = @alt_names
+1.3.6.1.4.1.57264.1.8 = ASN1:UTF8String:https://signing.example.com
+
+[alt_names]
+email.0 = signer@example.com
+EOF
+
+# Create signing config (separate from CSR config)
+cat > "${OUTPUT_DIR}"/signing.conf << EOF
+basicConstraints = critical,CA:FALSE
+keyUsage = critical,digitalSignature
+extendedKeyUsage = critical,codeSigning,clientAuth
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always
+subjectAltName = @alt_names
+1.3.6.1.4.1.57264.1.8 = ASN1:UTF8String:https://signing.example.com
+
+[alt_names]
+email.0 = signer@example.com
+EOF
+
+# Generate leaf CSR
+openssl req -new -key "${OUTPUT_DIR}"/leaf.key \
+    -config "${OUTPUT_DIR}"/leaf.conf \
+    -out "${OUTPUT_DIR}"/leaf.csr
+
+# Sign leaf certificate using the signing config
+openssl x509 -req -days 365 \
+    -in "${OUTPUT_DIR}"/leaf.csr \
+    -CA "${OUTPUT_DIR}"/ca.crt \
+    -CAkey "${OUTPUT_DIR}"/ca.key \
+    -CAcreateserial \
+    -extfile "${OUTPUT_DIR}"/signing.conf \
+    -out "${OUTPUT_DIR}"/leaf.crt
+
+# Create certificate chain
+cat "${OUTPUT_DIR}"/leaf.crt "${OUTPUT_DIR}"/ca.crt > "${OUTPUT_DIR}"/certificate_chain.pem

--- a/security/container-signing-poc/kyverno/Makefile
+++ b/security/container-signing-poc/kyverno/Makefile
@@ -1,37 +1,47 @@
-# build and install notation-external-signer
+# setup kyverno test for e2e
 
 SCRIPTS_DIR := scripts
 POLICY_DIR := policy
 
 NOTATION_DIR := ../notation
-EXAMPLES_DIR := $(NOTATION_DIR)/examples
-NOTATION_SIGNER := $(EXAMPLES_DIR)/rsassa-pss-sha512.sh
+NOTATION_EXAMPLES_DIR := $(NOTATION_DIR)/examples
+NOTATION_SIGNER := $(NOTATION_EXAMPLES_DIR)/rsassa-pss-sha512.sh
+NOTATION_TEST_IMAGE_UNSIGNED := busybox:1.36.0-glibc
+NOTATION_TEST_IMAGE_SIGNED := busybox:1.36.1-glibc
+NOTATION_TEST_DIGEST := sha256:28e01ab32c9dbcbaae96cf0d5b472f22e231d9e603811857b295e61197e40a9b
+
+COSIGN_DIR := ../cosign
+COSIGN_EXAMPLES_DIR := $(COSIGN_DIR)/examples
+COSIGN_TEST_IMAGE_UNSIGNED := alpine:3.20.2
+COSIGN_TEST_IMAGE_SIGNED := alpine:3.20.3
+COSIGN_TEST_DIGEST := sha256:33735bd63cf84d7e388d9f6d297d348c523c044410f553bd878c6d7829612735
 
 TEST_REGISTRY := 127.0.0.1:5001
 TEST_REGISTRY_NAME := kind-registry
 TEST_REGISTRY_IMAGE := registry:2
-TEST_IMAGE_UNSIGNED := busybox:1.36.0-glibc
-TEST_IMAGE_SIGNED := busybox:1.36.1-glibc
-TEST_DIGEST := sha256:28e01ab32c9dbcbaae96cf0d5b472f22e231d9e603811857b295e61197e40a9b
 
-CLUSTER_REGISTRY := 172.19.0.3:5000
+CLUSTER_REGISTRY := 172.18.0.2:5000
 
 SHELL := /bin/bash
 
-.PHONY: all test setup check-tools sign clean clean-tests
+.PHONY: all test setup check-tools sign clean clean-tests sign-notation sign-cosign
 
 all: check-tools
 	@echo "targets: test clean"
 
 test: check-tools setup sign tests
 e2e: check-tools setup-e2e tests
+notation-e2e: check-tools setup-e2e tests-notation
+cosign-e2e: check-tools setup-e2e tests-cosign
 
-.PHONY: tests test-pod test-deployment
+.PHONY: tests tests-notation tests-cosign
+.PHONY: test-pod test-deployment test-pod-notation test-pod-cosign test-deployment-notation test-deployment-cosign
 
 setup: setup-registry create-cluster install-kyverno install-notation-plugin certificates
-setup-e2e: create-cluster install-kyverno
+setup-e2e: setup-registry create-cluster install-kyverno
 
-.PHONY: setup-registry create-cluster install-kyverno install-notation-plugin install-policy certificates
+.PHONY: setup-registry create-cluster install-kyverno install-notation-plugin certificates
+.PHONY: install-policies install-policy-notation install-policy-cosign
 
 check-tools:
 	@type -a helm &>/dev/null || echo "error: Install helm: https://helm.sh/docs/intro/install/"
@@ -40,8 +50,8 @@ check-tools:
 	@type -a notation &>/dev/null || echo "error: Install notation: https://notaryproject.dev/docs/user-guides/installation/cli/"
 
 setup-registry:
-	docker run -d -p $(TEST_REGISTRY):5000 --name $(TEST_REGISTRY_NAME) $(TEST_REGISTRY_IMAGE)
-	for image in $(TEST_IMAGE_UNSIGNED) $(TEST_IMAGE_SIGNED); do \
+	docker run -d -p $(TEST_REGISTRY):5000 --network kind --name $(TEST_REGISTRY_NAME) $(TEST_REGISTRY_IMAGE)
+	for image in $(NOTATION_TEST_IMAGE_UNSIGNED) $(NOTATION_TEST_IMAGE_SIGNED) $(COSIGN_TEST_IMAGE_UNSIGNED) $(COSIGN_TEST_IMAGE_SIGNED); do \
 		docker pull $${image}; \
 		docker tag $${image} $(TEST_REGISTRY)/$${image}; \
 		docker push $(TEST_REGISTRY)/$${image}; \
@@ -66,39 +76,84 @@ install-notation-plugin:
 
 certificates:
 	make -C $(NOTATION_DIR) certificates
+	make -C $(COSIGN_DIR) certificates
 
-install-policy:
-	# replace example cert with the generated certs
-	cat $(POLICY_DIR)/kyverno-policy.yaml | \
+install-policies: install-policy-notation install-policy-cosign
+
+install-policy-notation:
+	# replace example cert with the generated certs for notation
+	cat $(POLICY_DIR)/kyverno-policy-notation.yaml | \
 		sed -re '/-----BEGIN/,/END CERTIFICATE-----/d' | \
-		{ cat -; cat $(EXAMPLES_DIR)/ca.crt | sed -e 's/^/              /g'; } | \
+		{ cat -; cat $(NOTATION_EXAMPLES_DIR)/ca.crt | sed -e 's/^/              /g'; } | \
 	kubectl apply -f -
 	sleep 30
 
-sign:
-	make -C $(NOTATION_DIR) sign TEST_IMAGE_SIGN=$(TEST_REGISTRY)/$(TEST_IMAGE_SIGNED)
+install-policy-cosign:
+	# for cosign, we must use leaf.crt, not root ca
+	cat $(POLICY_DIR)/kyverno-policy-cosign.yaml | \
+		sed -re '/-----BEGIN/,/END CERTIFICATE-----/d' | \
+		{ cat -; cat $(COSIGN_EXAMPLES_DIR)/leaf.crt | sed -e 's/^/              /g'; } | \
+	kubectl apply -f -
+	sleep 30
 
-tests: install-policy test-pod test-deployment
+sign: sign-notation sign-cosign
+
+sign-notation:
+	make -C $(NOTATION_DIR) sign TEST_IMAGE_SIGN=$(TEST_REGISTRY)/$(NOTATION_TEST_IMAGE_SIGNED)
+
+sign-cosign:
+	make -C $(COSIGN_DIR) sign TEST_IMAGE_SIGN=$(TEST_REGISTRY)/$(COSIGN_TEST_IMAGE_SIGNED)
+
+tests: install-policies test-pod test-deployment
 	sleep 5
 	kubectl get pods -A
 	@echo "Success (if only pods with success are visible - ignore the ImagePull issues)"
 
-test-pod:
-	kubectl run --image $(CLUSTER_REGISTRY)/$(TEST_IMAGE_UNSIGNED) pod-fail || true
-	kubectl run --image $(CLUSTER_REGISTRY)/$(TEST_IMAGE_SIGNED) pod-success
+tests-notation: sign-notation install-policy-notation test-pod-notation test-deployment-notation
+	sleep 5
+	kubectl get pods -A
+	@echo "Success (if only pods with success are visible - ignore the ImagePull issues)"
 
-test-deployment:
-	kubectl create deployment --image $(CLUSTER_REGISTRY)/$(TEST_IMAGE_UNSIGNED) deployment-fail || true
-	kubectl create deployment --image $(CLUSTER_REGISTRY)/$(TEST_IMAGE_SIGNED) deployment-success
+tests-cosign: sign-cosign install-policy-cosign test-pod-cosign test-deployment-cosign
+	sleep 5
+	kubectl get pods -A
+	@echo "Success (if only pods with success are visible - ignore the ImagePull issues)"
+
+test-pod: test-pod-notation test-pod-cosign
+
+test-pod-notation:
+	kubectl run --image $(CLUSTER_REGISTRY)/$(NOTATION_TEST_IMAGE_UNSIGNED) pod-fail-notation || true
+	kubectl run --image $(CLUSTER_REGISTRY)/$(NOTATION_TEST_IMAGE_SIGNED) pod-success-notation || true
+
+test-pod-cosign:
+	kubectl run --image $(CLUSTER_REGISTRY)/$(COSIGN_TEST_IMAGE_UNSIGNED) pod-fail-cosign || true
+	kubectl run --image $(CLUSTER_REGISTRY)/$(COSIGN_TEST_IMAGE_SIGNED) pod-success-cosign || true
+
+test-deployment: test-deployment-notation test-deployment-cosign
+
+test-deployment-notation:
+	kubectl create deployment --image $(CLUSTER_REGISTRY)/$(NOTATION_TEST_IMAGE_UNSIGNED) deployment-fail-notation || true
+	kubectl create deployment --image $(CLUSTER_REGISTRY)/$(NOTATION_TEST_IMAGE_SIGNED) deployment-success-notation || true
+
+test-deployment-cosign:
+	kubectl create deployment --image $(CLUSTER_REGISTRY)/$(COSIGN_TEST_IMAGE_UNSIGNED) deployment-fail-cosign || true
+	kubectl create deployment --image $(CLUSTER_REGISTRY)/$(COSIGN_TEST_IMAGE_SIGNED) deployment-success-cosign || true
 
 clean-tests:
-	-kubectl delete pod pod-fail
-	-kubectl delete deployment deployment-fail
-	-kubectl delete pod pod-success
-	-kubectl delete deployment deployment-success
+	# notation
+	-kubectl delete pod pod-fail-notation || true
+	-kubectl delete deployment deployment-fail-notation || true
+	-kubectl delete pod pod-success-notation || true
+	-kubectl delete deployment deployment-success-notation || true
+	# cosign
+	-kubectl delete pod pod-fail-cosign || true
+	-kubectl delete deployment deployment-fail-cosign || true
+	-kubectl delete pod pod-success-cosign || true
+	-kubectl delete deployment deployment-success-cosign || true
 
 clean: clean-e2e
 	make -C $(NOTATION_DIR) clean
+	make -C $(COSIGN_DIR) clean
 
 clean-e2e:
 	-docker rm -f $(TEST_REGISTRY_NAME)

--- a/security/container-signing-poc/kyverno/policy/kyverno-policy-cosign.yaml
+++ b/security/container-signing-poc/kyverno/policy/kyverno-policy-cosign.yaml
@@ -1,0 +1,60 @@
+apiVersion: kyverno.io/v2beta1
+kind: ClusterPolicy
+metadata:
+  name: check-image-cosign
+spec:
+  validationFailureAction: Enforce
+  webhookTimeoutSeconds: 30
+  failurePolicy: Fail
+  rules:
+  - name: verify-signature-cosign
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    verifyImages:
+    - type: Cosign
+      imageReferences:
+      - "172.18.0.2:*/alpine*"
+      attestors:
+      - count: 1
+        entries:
+        - certificates:
+            rekor:
+              ignoreTlog: true
+            ctlog:
+              ignoreSCT: true
+            cert: |-
+              -----BEGIN CERTIFICATE-----
+              MIIFjTCCA3WgAwIBAgIUeHtBTjMbNnQiHKLRxWgwbaVWKEAwDQYJKoZIhvcNAQEL
+              BQAwEjEQMA4GA1UEAwwHUm9vdCBDQTAeFw0yNDExMDQxNTQzMzFaFw0yNTExMDQx
+              NTQzMzFaMB0xGzAZBgNVBAMMEnNpZ25lckBleGFtcGxlLmNvbTCCAiIwDQYJKoZI
+              hvcNAQEBBQADggIPADCCAgoCggIBAKXkd8isJItdtGumOFwNJOC3MI+iy7K44GZN
+              mvVozTf4hT0qWdRn9M6Ubz95VcW0IDnVsrI34oAIs2fmq3zHo/yDOSsj5+TQ7Ymg
+              axF9r1ThcNot6FlgdemQIhUXE9LOy9vPH5FAinvuWFwE7RfzLAnAUBhtVYbxq5HZ
+              qpKabHahMLXt1ijKaqzB22AU41Qtls1Kf2qQx8auBC/9Vfo33S0NPf0uxqn7iQ+E
+              vZGxT0U0bQoNpbLrwhyZF46HWlZ2rBzLmU0MZiotOQVWIsz17pXf/tgbq6PsF6QT
+              IRnmvYXEfK+GEtqkWJaYIvlEYI8xH0+AkqOpzmzNEzwaqSNJVXhk05kucq2uPcV9
+              ejSpLOVP9fMBBEXl6ps9VaMH0k0kY6amcI6cUT12rcU6Ryg3uAHMS//gO8qRtziN
+              z+Ei/sSBDa2AnYK0e9GGYxdrxvx54mhF8ZgSYQeBEPsedFH6k5TA5kSNgS7aOR/Y
+              rrPJySB76oe8+WmVZ8eFe9vM2hm4d8DioQo5LILbsEixwrhXOUP5zBXu3UOsyqXy
+              C8ddwKrNGvNPrQCtJ6fgpqwJ/3xW2rx9Av+YEvHvJ+L2+gdNBAZ1i+7dVJvjOhl6
+              eiSsYWmoh2D17ZNLt85npel82x7vjmHKiu5wfOietImWOzPpXUNgYOSaBZqDuE6y
+              FWpmmqxzAgMBAAGjgc8wgcwwDAYDVR0TAQH/BAIwADAOBgNVHQ8BAf8EBAMCB4Aw
+              IAYDVR0lAQH/BBYwFAYIKwYBBQUHAwMGCCsGAQUFBwMCMB0GA1UdDgQWBBTFzATN
+              ap91tbNSFo1r0xYXBnGY+DAfBgNVHSMEGDAWgBQT4bXDf9z9ku5Sq/I+aanUbPyf
+              xzAdBgNVHREEFjAUgRJzaWduZXJAZXhhbXBsZS5jb20wKwYKKwYBBAGDvzABCAQd
+              DBtodHRwczovL3NpZ25pbmcuZXhhbXBsZS5jb20wDQYJKoZIhvcNAQELBQADggIB
+              AAlJc+xTqQAowKfYv+tkHVRvtLwxLFp2BobVW7f9CsoSgfJWnbQhJF4t+4wHXG2f
+              H1Svvz7GWz1uIhRY8Yw7pFDj3N9VY3ndL53eFpEOH5yk7kVoMXw/TugUyk4alHas
+              AowWwgzFEIZyVDjt3agU9B/2YQYcRRlkFHxwJ4A//GNR3pEkwuW3fltVpp/ce3wO
+              rl1Q8pr5laJ/g3T72OVBbxjx3uPbePi16iZaGTXsErF68vUlc/qxp26nbmst5pV9
+              Vasd0DwkBW0lXHhfKSppMB1AvTWCy8HV9CavMdjuvelfaaLUl6c1XmhNtD2Xvk38
+              FjK2Kvr1Oxup5TW4hMKqHXiYjAC35NxUt7k8Oed/UY++e6T94M0zHnz/W/8lrERQ
+              DLFEAf2NzhIV/vFOtZiDViDCEvWs0oHGltxYN4FnYry8O8bkT1HT3FldMW3T+9Kv
+              9ARzVyGN7UyaHWte0aBE0CsGIjgoBeFMzusRXYN6QikY0aUZROtyRiT4ouK0YHDW
+              /o1kkj0T3K5jr9aczam3LH2aKDAB8DqnGrJcTF48+jcrEKt1NKhsqNd+IX7F98Ud
+              JSnGcUkXE9DLlnA4QyoyPp6vH36Ur9oTwePS9v3RQVXOmIk3FwEMEp7r4jgzJKWA
+              CHHIN0lg33qUc0QUsj8N/OsPAHefEknnAY3UHMgJWPAf
+              -----END CERTIFICATE-----

--- a/security/container-signing-poc/kyverno/policy/kyverno-policy-notation.yaml
+++ b/security/container-signing-poc/kyverno/policy/kyverno-policy-notation.yaml
@@ -1,13 +1,13 @@
 apiVersion: kyverno.io/v2beta1
 kind: ClusterPolicy
 metadata:
-  name: check-image-notary
+  name: check-image-notation
 spec:
   validationFailureAction: Enforce
   webhookTimeoutSeconds: 30
   failurePolicy: Fail
   rules:
-  - name: verify-signature-notary
+  - name: verify-signature-notation
     match:
       any:
       - resources:
@@ -16,7 +16,7 @@ spec:
     verifyImages:
     - type: Notary
       imageReferences:
-      - "172.19.0.3:*/*"
+      - "172.18.0.2:*/busybox*"
       attestors:
       - count: 1
         entries:

--- a/security/container-signing-poc/kyverno/scripts/kind-cluster.sh
+++ b/security/container-signing-poc/kyverno/scripts/kind-cluster.sh
@@ -2,14 +2,9 @@
 
 set -eux
 
-# 1. Create registry container unless it already exists
+# 1. Registry container config unless it already exists
 REG_NAME="kind-registry"
 REG_PORT="5001"
-
-if [[ "$(docker inspect -f '{{.State.Running}}' "${REG_NAME}" 2>/dev/null || true)" != 'true' ]]; then
-    docker run -d --restart=always -p "127.0.0.1:${REG_PORT}:5000" \
-        --network bridge --name "${REG_NAME}" registry:2
-fi
 
 # 2. Create kind cluster with containerd registry config dir enabled
 # TODO: kind will eventually enable this by default and this patch will

--- a/security/container-signing-poc/notation/README.md
+++ b/security/container-signing-poc/notation/README.md
@@ -1,4 +1,5 @@
 <!-- markdownlint-disable line-length -->
+<!-- cSpell:ignore rsassa -->
 
 # External Signer Plugin for Notation
 

--- a/security/container-signing-poc/notation/examples/.gitignore
+++ b/security/container-signing-poc/notation/examples/.gitignore
@@ -2,3 +2,4 @@
 *.crt
 *.key
 *.csr
+*.srl


### PR DESCRIPTION
Add cosign as option to container-signing-poc. This allows comparison between cosign and notation for using external signing service.

Note that `make e2e` is quite a mess now and should be refactored in a follow-up. `make test` directly in `kyverno` is working better.