### PR TITLE
update kubelogin-poc to include offline_access

### DIFF
--- a/security/kubelogin-poc/README.md
+++ b/security/kubelogin-poc/README.md
@@ -132,6 +132,8 @@ look like:
       - --oidc-extra-scope=email
       - --oidc-extra-scope=profile
       - --oidc-extra-scope=groups
+      # if you want to use refresh tokens, add offline_access scope
+      - --oidc-extra-scope=offline_access
       - --grant-type=password
       - --insecure-skip-tls-verify
 ```
@@ -194,6 +196,8 @@ to look like:
       - --oidc-extra-scope=email
       - --oidc-extra-scope=profile
       - --oidc-extra-scope=groups
+      # if you want to use refresh tokens, add offline_access scope
+      - --oidc-extra-scope=offline_access
       - --insecure-skip-tls-verify
       - --use-device-code
 ```

--- a/security/kubelogin-poc/kubeconfig.device-code.example
+++ b/security/kubelogin-poc/kubeconfig.device-code.example
@@ -27,14 +27,14 @@ users:
       - get-token
       - --oidc-issuer-url=https://dex.example.com:32000
       - --oidc-client-id=kubelogin-test
-      # - --oidc-client-secret=kubelogin-test-secret
       - --oidc-pkce-method=S256
       - --oidc-extra-scope=email
       - --oidc-extra-scope=profile
       - --oidc-extra-scope=groups
-      # - --grant-type=password
+      - --oidc-extra-scope=offline_access
+      - --oidc-pkce-method=S256
+      - --grant-type=device-code
       - --insecure-skip-tls-verify
-      - --use-device-code
       # enable verbose logs
       - -v1
       command: kubectl

--- a/security/kubelogin-poc/kubeconfig.password.example
+++ b/security/kubelogin-poc/kubeconfig.password.example
@@ -31,6 +31,7 @@ users:
       - --oidc-extra-scope=email
       - --oidc-extra-scope=profile
       - --oidc-extra-scope=groups
+      - --oidc-extra-scope=offline_access
       - --grant-type=password
       - --insecure-skip-tls-verify
       # enable verbose logs

--- a/security/kubelogin-poc/run.sh
+++ b/security/kubelogin-poc/run.sh
@@ -57,6 +57,7 @@ if [[ "${TYPE}" == "password" ]]; then
         --exec-arg=--oidc-extra-scope=email \
         --exec-arg=--oidc-extra-scope=profile \
         --exec-arg=--oidc-extra-scope=groups \
+        --exec-arg=--oidc-extra-scope=offline_access \
         --exec-arg=--insecure-skip-tls-verify \
         --exec-arg=--oidc-client-secret=kubelogin-test-secret \
         --exec-arg=--grant-type=password \
@@ -72,6 +73,7 @@ else
         --exec-arg=--oidc-extra-scope=email \
         --exec-arg=--oidc-extra-scope=profile \
         --exec-arg=--oidc-extra-scope=groups \
+        --exec-arg=--oidc-extra-scope=offline_access \
         --exec-arg=--insecure-skip-tls-verify \
         --exec-arg=--oidc-pkce-method=S256 \
         --exec-arg=--grant-type=device-code \


### PR DESCRIPTION
Update Kubelogin POC to include offline_access scope for enabling refresh tokens. Especially device-code flow is annoying if the idToken would expire as it would lead to another browser login.

Also cleanup the kubeconfig example to use real values from run.sh for device-code flow.